### PR TITLE
feat(list): add --sort and --order flags

### DIFF
--- a/src/adapters/rest.ts
+++ b/src/adapters/rest.ts
@@ -109,46 +109,28 @@ export class RestAdapter implements WpBackend {
     const params: Record<string, string | number> = {
       per_page: filters.perPage ?? 20,
       page: filters.page ?? 1,
-      orderby: 'date',
-      order: 'desc',
+      ...restSortParams(filters),
     };
 
-    if (filters.type) {
-      params.media_type = filters.type.startsWith('image') ? 'image' : filters.type;
-    }
-    if (filters.postId) {
-      params.parent = filters.postId;
-    }
-    if (filters.since) {
-      params.after = filters.since;
-    }
-
+    applyCommonFilters(params, filters);
     const raw = await this.request<WpMediaResponse[]>(this.apiUrl('/media', params));
-    return raw.map(mapWpMediaToItem);
+    const items = raw.map(mapWpMediaToItem);
+    return applySizeSort(items, filters);
   }
 
   async listMediaPage(filters: ListFilters): Promise<import('./types.ts').PagedResult<MediaItem>> {
     const params: Record<string, string | number> = {
       per_page: Math.min(filters.perPage ?? 50, 100),
       page: filters.page ?? 1,
-      orderby: 'date',
-      order: 'desc',
+      ...restSortParams(filters),
     };
 
-    if (filters.type) {
-      params.media_type = filters.type.startsWith('image') ? 'image' : filters.type;
-    }
-    if (filters.postId) {
-      params.parent = filters.postId;
-    }
-    if (filters.since) {
-      params.after = filters.since;
-    }
-
+    applyCommonFilters(params, filters);
     const { data, headers } = await this.requestRaw<WpMediaResponse[]>(this.apiUrl('/media', params));
     const total = parseInt(headers.get('X-WP-Total') ?? '0', 10);
     const totalPages = parseInt(headers.get('X-WP-TotalPages') ?? '1', 10);
-    return { items: data.map(mapWpMediaToItem), total, totalPages };
+    const items = applySizeSort(data.map(mapWpMediaToItem), filters);
+    return { items, total, totalPages };
   }
 
   async getMedia(id: number): Promise<MediaItem> {
@@ -369,6 +351,40 @@ interface WpPostResponse {
   type: string;
   featured_media?: number;
   content?: { rendered: string; raw?: string };
+}
+
+// -- Sort / filter helpers ----------------------------------------------------
+
+function restSortParams(filters: ListFilters): Record<string, string> {
+  const wpOrderby: Record<string, string> = {
+    date: 'date',
+    name: 'title',
+    id: 'id',
+    // 'size' has no server-side equivalent — handled client-side
+  };
+  const sortBy = filters.sortBy ?? 'date';
+  return {
+    orderby: wpOrderby[sortBy] ?? 'date',
+    order: filters.sortOrder ?? 'desc',
+  };
+}
+
+function applyCommonFilters(params: Record<string, string | number>, filters: ListFilters): void {
+  if (filters.type) {
+    params.media_type = filters.type.startsWith('image') ? 'image' : filters.type;
+  }
+  if (filters.postId) {
+    params.parent = filters.postId;
+  }
+  if (filters.since) {
+    params.after = filters.since;
+  }
+}
+
+function applySizeSort(items: MediaItem[], filters: ListFilters): MediaItem[] {
+  if (filters.sortBy !== 'size') return items;
+  const dir = filters.sortOrder === 'asc' ? 1 : -1;
+  return [...items].sort((a, b) => dir * ((a.sizeBytes ?? 0) - (b.sizeBytes ?? 0)));
 }
 
 // -- Mapping helpers ----------------------------------------------------------

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -57,6 +57,9 @@ export interface MediaSize {
   sizeBytes?: number;
 }
 
+export type SortField = 'date' | 'name' | 'size' | 'id';
+export type SortOrder = 'asc' | 'desc';
+
 export interface ListFilters {
   /** Only items not yet processed by localpress. */
   unoptimized?: boolean;
@@ -68,6 +71,10 @@ export interface ListFilters {
   since?: string;
   /** Bytes — only items larger than this. */
   largerThan?: number;
+  /** Sort field. 'size' is applied client-side; others pass to the REST API. */
+  sortBy?: SortField;
+  /** Sort direction. */
+  sortOrder?: SortOrder;
   /** Pagination. */
   page?: number;
   perPage?: number;

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -8,7 +8,7 @@
 
 import type { Command } from 'commander';
 import { AdapterResolver } from '../../adapters/resolver.ts';
-import type { ListFilters, MediaItem } from '../../adapters/types.ts';
+import type { ListFilters, MediaItem, SortField, SortOrder } from '../../adapters/types.ts';
 import type { MediaBrowserAction } from '../components/MediaBrowser.tsx';
 import { SiteDb } from '../../engine/state/db.ts';
 import { loadConfig, getSiteDbPath, resolveActiveSite } from '../utils/config.ts';
@@ -27,6 +27,8 @@ export function registerListCommand(program: Command): void {
     .option('--larger-than <bytes>', 'minimum size in bytes', (v) => Number.parseInt(v, 10))
     .option('--limit <n>', 'items per page (max 100)', (v) => Number.parseInt(v, 10))
     .option('--page <n>', 'page number (default 1)', (v) => Number.parseInt(v, 10))
+    .option('--sort <field>', 'sort by: date (default), name, size, id')
+    .option('--order <dir>', 'sort direction: desc (default) or asc')
     .option('-i, --interactive', 'browse with keyboard navigation')
     .action(async (options) => {
       const parentOpts = program.opts();
@@ -35,6 +37,9 @@ export function registerListCommand(program: Command): void {
       const resolver = new AdapterResolver(site);
       const adapter = resolver.resolve('list');
 
+      const VALID_SORT_FIELDS: SortField[] = ['date', 'name', 'size', 'id'];
+      const VALID_SORT_ORDERS: SortOrder[] = ['asc', 'desc'];
+
       const filters: ListFilters = {
         type: options.type,
         postId: options.post,
@@ -42,6 +47,8 @@ export function registerListCommand(program: Command): void {
         largerThan: options.largerThan,
         perPage: Math.min(options.limit ?? 50, 100),
         page: options.page ?? 1,
+        sortBy: VALID_SORT_FIELDS.includes(options.sort) ? (options.sort as SortField) : undefined,
+        sortOrder: VALID_SORT_ORDERS.includes(options.order) ? (options.order as SortOrder) : undefined,
       };
 
       // Interactive TUI mode.
@@ -85,6 +92,8 @@ export function registerListCommand(program: Command): void {
             totalPages: result.totalPages,
             currentPage: filters.page ?? 1,
             processedIds,
+            sortBy: filters.sortBy,
+            sortOrder: filters.sortOrder,
             onAction: (action) => { pending.action = action; },
             onPageChange: async (page: number) => {
               const r = await adapter.listMediaPage({ ...filters, page });
@@ -158,7 +167,10 @@ export function registerListCommand(program: Command): void {
       const from = (pageNum - 1) * perPage + 1;
       const to = Math.min(from + items.length - 1, total);
       const pageInfo = totalPages > 1 ? `  (page ${pageNum}/${totalPages})` : '';
-      info(`Showing ${from}–${to} of ${total} item(s)${pageInfo}:\n`);
+      const sortInfo = filters.sortBy && filters.sortBy !== 'date'
+        ? `  sorted by ${filters.sortBy} ${filters.sortOrder ?? 'desc'}`
+        : '';
+      info(`Showing ${from}–${to} of ${total} item(s)${pageInfo}${sortInfo}:\n`);
 
       for (const item of items) {
         const size = item.sizeBytes ? formatBytes(item.sizeBytes) : '?';
@@ -167,7 +179,8 @@ export function registerListCommand(program: Command): void {
       }
 
       if (pageNum < totalPages) {
-        info(`\nNext page: localpress list --page ${pageNum + 1}`);
+        const sortFlags = filters.sortBy ? ` --sort ${filters.sortBy}${filters.sortOrder ? ` --order ${filters.sortOrder}` : ''}` : '';
+        info(`\nNext page: localpress list --page ${pageNum + 1}${sortFlags}`);
       }
     });
 }

--- a/src/cli/components/MediaBrowser.tsx
+++ b/src/cli/components/MediaBrowser.tsx
@@ -10,7 +10,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { Box, Text, useInput, useApp } from 'ink';
-import type { MediaItem, PagedResult } from '../../adapters/types.ts';
+import type { MediaItem, PagedResult, SortField, SortOrder } from '../../adapters/types.ts';
 
 export type MediaBrowserAction =
   | { type: 'quit' }
@@ -24,6 +24,8 @@ interface Props {
   totalPages: number;
   currentPage: number;
   processedIds: Set<number>;
+  sortBy?: SortField;
+  sortOrder?: SortOrder;
   onAction: (action: MediaBrowserAction) => void;
   onPageChange: (page: number) => Promise<PagedResult<MediaItem>>;
 }
@@ -60,6 +62,8 @@ export function MediaBrowser({
   totalPages: initialTotalPages,
   currentPage: initialPage,
   processedIds,
+  sortBy,
+  sortOrder,
   onAction,
   onPageChange,
 }: Props) {
@@ -176,6 +180,9 @@ export function MediaBrowser({
         <Box gap={1}>
           <Text bold color="green">localPress</Text>
           <Text dimColor>— media library</Text>
+          {sortBy && sortBy !== 'date' && (
+            <Text dimColor>· {sortBy} {sortOrder ?? 'desc'}</Text>
+          )}
         </Box>
         <Text dimColor>Page {page}/{totalPages} · {total} total</Text>
       </Box>


### PR DESCRIPTION
## Summary

- Adds `--sort <field>` flag: `date` (default), `name`, `size`, `id`
- Adds `--order <dir>` flag: `desc` (default) or `asc`
- `date`, `name`, `id` pass directly to the WP REST API as `orderby`; `size` is applied client-side after the fetch
- Plain output shows active sort in the header line and preserves flags in the `Next page:` hint
- Interactive TUI header shows sort context (e.g. `· size desc`) when non-default
- `SortField` and `SortOrder` types exported from `adapters/types.ts`
- `restSortParams` / `applyCommonFilters` / `applySizeSort` helpers replace duplicated inline params in `RestAdapter`

## Test plan

- [ ] `localpress list --sort size --order asc` returns items sorted smallest-first
- [ ] `localpress list --sort name` returns alphabetical order
- [ ] `localpress list --sort date --order asc` returns oldest-first
- [ ] Plain output shows `sorted by size asc` in header when non-default sort is active
- [ ] Next page hint includes `--sort`/`--order` flags
- [ ] `localpress list -i --sort size` shows `· size desc` in TUI header
- [ ] `bun run typecheck` passes
- [ ] `bun test test/unit/` — 36 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)