### PR TITLE
feat: add stats command

### DIFF
--- a/src/cli/commands/stats.ts
+++ b/src/cli/commands/stats.ts
@@ -1,0 +1,107 @@
+/**
+ * `localpress stats` — cumulative savings and processing history dashboard.
+ *
+ * Reads entirely from the local SQLite database — no network calls.
+ * Falls back gracefully when no history exists yet.
+ */
+
+import type { Command } from 'commander';
+import { SiteDb } from '../../engine/state/db.ts';
+import { loadConfig, getSiteDbPath, resolveActiveSite } from '../utils/config.ts';
+import { error, info, printJson } from '../utils/output.ts';
+
+export function registerStatsCommand(program: Command): void {
+  program
+    .command('stats')
+    .description('Show cumulative processing stats for the active site')
+    .option('--all-sites', 'show stats for every configured site')
+    .action(async (options) => {
+      const parentOpts = program.opts();
+      const config = await loadConfig();
+
+      const sites = options.allSites
+        ? Object.values(config.sites)
+        : [resolveActiveSite(config, parentOpts.site)];
+
+      const results = [];
+
+      for (const site of sites) {
+        const dbPath = getSiteDbPath(site.name);
+        let db: SiteDb;
+        try {
+          db = SiteDb.init(dbPath);
+        } catch {
+          if (parentOpts.json) {
+            results.push({ site: site.name, error: 'database unavailable' });
+          } else {
+            error(`No stats database for site "${site.name}" — run some operations first.`);
+          }
+          continue;
+        }
+
+        const stats = db.getStats(site.name);
+        db.close();
+        results.push({ site: site.name, stats });
+      }
+
+      if (parentOpts.json) {
+        printJson(results.length === 1 ? results[0] : results);
+        return;
+      }
+
+      for (const { site, stats, error: err } of results as Array<{
+        site: string;
+        stats?: import('../../engine/state/db.ts').SiteStats;
+        error?: string;
+      }>) {
+        if (err || !stats) {
+          error(`${site}: ${err ?? 'no data'}`);
+          continue;
+        }
+
+        if (results.length > 1) {
+          info(`\n── ${site} ──────────────────────────────`);
+        }
+
+        if (stats.totalOps === 0) {
+          info(`No processing history yet for "${site}". Run localpress optimize, convert, resize, or remove-bg to start.`);
+          continue;
+        }
+
+        const saved = formatBytes(stats.bytesSaved);
+        const pct = stats.bytesIn > 0
+          ? ` (${((stats.bytesSaved / stats.bytesIn) * 100).toFixed(1)}% reduction)`
+          : '';
+        const lastRan = stats.lastRanAt
+          ? new Date(stats.lastRanAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+          : '—';
+
+        info(`\n  Site            ${site}`);
+        info(`  Files touched   ${stats.filesTouched.toLocaleString()}`);
+        info(`  Operations      ${stats.succeeded.toLocaleString()} succeeded  /  ${(stats.totalOps - stats.succeeded).toLocaleString()} failed`);
+        info(`  Bytes saved     ${saved}${pct}`);
+        info(`  Last run        ${lastRan}`);
+
+        if (stats.byOperation.length > 0) {
+          info('\n  Breakdown by operation:\n');
+          const colW = Math.max(...stats.byOperation.map((o) => o.operation.length)) + 2;
+          for (const op of stats.byOperation) {
+            const name = op.operation.padEnd(colW);
+            const count = String(op.succeeded).padStart(5);
+            const opSaved = op.bytesSaved > 0 ? `  saved ${formatBytes(op.bytesSaved)}` : '';
+            const avg = op.avgDurationMs ? `  avg ${op.avgDurationMs}ms` : '';
+            info(`    ${name}${count} ops${opSaved}${avg}`);
+          }
+        }
+
+        info('');
+      }
+    });
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,6 +23,7 @@ import { registerReferencesCommand } from './commands/references.ts';
 import { registerRemoveBgCommand } from './commands/remove-bg.ts';
 import { registerResizeCommand } from './commands/resize.ts';
 import { registerShowCommand } from './commands/show.ts';
+import { registerStatsCommand } from './commands/stats.ts';
 import { registerSitesCommand } from './commands/sites.ts';
 import { setOutputOptions } from './utils/output.ts';
 
@@ -62,6 +63,7 @@ registerDoctorCommand(program);
 registerConfigCommand(program);
 registerListCommand(program);
 registerShowCommand(program);
+registerStatsCommand(program);
 registerAuditCommand(program);
 registerOptimizeCommand(program);
 registerConvertCommand(program);

--- a/src/engine/state/db.ts
+++ b/src/engine/state/db.ts
@@ -209,6 +209,58 @@ export class SiteDb {
     return row ? mapProcessingRow(row) : null;
   }
 
+  // Stats ---------------------------------------------------------------------
+
+  getStats(siteName: string): SiteStats {
+    const ops = this.db.query(
+      `SELECT operation,
+              COUNT(*)                                          AS total,
+              SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) AS succeeded,
+              SUM(CASE WHEN status = 'failure' THEN 1 ELSE 0 END) AS failed,
+              SUM(CASE WHEN bytes_before > bytes_after THEN bytes_before - bytes_after ELSE 0 END) AS bytes_saved,
+              SUM(bytes_before)                                 AS bytes_in,
+              SUM(bytes_after)                                  AS bytes_out,
+              SUM(duration_ms)                                  AS total_ms,
+              MAX(ran_at)                                       AS last_ran_at
+       FROM processing_history
+       WHERE site_name = ?
+       GROUP BY operation
+       ORDER BY total DESC`,
+    ).all(siteName) as RawOpStat[];
+
+    const totals = this.db.query(
+      `SELECT COUNT(DISTINCT wp_id)                                       AS files_touched,
+              SUM(CASE WHEN bytes_before > bytes_after THEN bytes_before - bytes_after ELSE 0 END) AS bytes_saved,
+              SUM(bytes_before)                                           AS bytes_in,
+              COUNT(*)                                                    AS total_ops,
+              SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END)        AS succeeded,
+              MAX(ran_at)                                                 AS last_ran_at
+       FROM processing_history
+       WHERE site_name = ?`,
+    ).get(siteName) as RawTotalStat | null;
+
+    return {
+      siteName,
+      filesTouched: totals?.files_touched ?? 0,
+      totalOps: totals?.total_ops ?? 0,
+      succeeded: totals?.succeeded ?? 0,
+      bytesSaved: totals?.bytes_saved ?? 0,
+      bytesIn: totals?.bytes_in ?? 0,
+      lastRanAt: totals?.last_ran_at ?? null,
+      byOperation: ops.map((r) => ({
+        operation: r.operation,
+        total: r.total,
+        succeeded: r.succeeded,
+        failed: r.failed,
+        bytesSaved: r.bytes_saved ?? 0,
+        bytesIn: r.bytes_in ?? 0,
+        bytesOut: r.bytes_out ?? 0,
+        avgDurationMs: r.total_ms && r.succeeded ? Math.round(r.total_ms / r.succeeded) : null,
+        lastRanAt: r.last_ran_at,
+      })),
+    };
+  }
+
   // Lifecycle -----------------------------------------------------------------
 
   close(): void {
@@ -278,6 +330,52 @@ function mapProcessingRow(row: RawProcessingRow): ProcessingHistoryRecord {
     status: row.status,
     errorMessage: row.error_message,
   };
+}
+
+// -- Stats types --------------------------------------------------------------
+
+export interface OperationStat {
+  operation: string;
+  total: number;
+  succeeded: number;
+  failed: number;
+  bytesSaved: number;
+  bytesIn: number;
+  bytesOut: number;
+  avgDurationMs: number | null;
+  lastRanAt: number;
+}
+
+export interface SiteStats {
+  siteName: string;
+  filesTouched: number;
+  totalOps: number;
+  succeeded: number;
+  bytesSaved: number;
+  bytesIn: number;
+  lastRanAt: number | null;
+  byOperation: OperationStat[];
+}
+
+interface RawOpStat {
+  operation: string;
+  total: number;
+  succeeded: number;
+  failed: number;
+  bytes_saved: number | null;
+  bytes_in: number | null;
+  bytes_out: number | null;
+  total_ms: number | null;
+  last_ran_at: number;
+}
+
+interface RawTotalStat {
+  files_touched: number;
+  bytes_saved: number | null;
+  bytes_in: number | null;
+  total_ops: number;
+  succeeded: number;
+  last_ran_at: number | null;
 }
 
 /** Read the current schema version stored in the DB. Returns 0 if no version row exists. */


### PR DESCRIPTION
## Summary

- New `localpress stats` command — reads entirely from local SQLite, zero network calls
- Shows: site name, files touched, ops succeeded/failed, total bytes saved (with % reduction), last run date
- Per-operation breakdown table: op name, count, bytes saved, avg duration
- `--all-sites` iterates every site in config
- `--json` outputs `{ site, stats: { filesTouched, totalOps, bytesSaved, bytesIn, byOperation[] } }`
- Graceful fallback when no DB exists yet ("run some operations first")
- `getStats()` method added to `SiteDb` using two aggregate SQL queries
- `SiteStats` and `OperationStat` types exported from `db.ts`

## Test plan

- [ ] `localpress stats` with no history prints friendly empty-state message
- [ ] After running `localpress optimize`, `stats` shows correct file count and bytes saved
- [ ] `--all-sites` shows a section per configured site
- [ ] `localpress stats --json` outputs valid JSON with expected shape
- [ ] `bun run typecheck` passes
- [ ] `bun test test/unit/` — 36 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)