### PR TITLE
feat: add caption command for local AI alt-text generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,12 @@ jobs:
             wp rewrite flush --hard \
               --path=/var/www/html --allow-root
 
+            # Apache strips the Authorization header before PHP sees it in some
+            # configurations. This rewrite rule passes it through explicitly so
+            # WordPress Application Password auth works over HTTP.
+            sed -i '/RewriteEngine On/a RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]' \
+              /var/www/html/.htaccess
+
             APP_PASS=$(wp user application-password create admin "ci-test" \
               --porcelain --path=/var/www/html --allow-root)
             echo "APP_PASS=$APP_PASS" > /tmp/wp-test-env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,9 @@ jobs:
           source /tmp/wp-test-env
           echo "Polling REST API until ready..."
           for i in $(seq 1 20); do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            STATUS=$(curl -sL -o /dev/null -w "%{http_code}" \
               -u "admin:$APP_PASS" \
-              http://localhost:8880/wp-json/wp/v2/media)
+              http://localhost:8880/wp-json/wp/v2/media/)
             if [ "$STATUS" = "200" ]; then
               echo "REST API is ready (HTTP $STATUS)"
               exit 0
@@ -130,7 +130,7 @@ jobs:
             sleep 3
           done
           echo "ERROR: REST API never became ready"
-          curl -v -u "admin:$APP_PASS" http://localhost:8880/wp-json/wp/v2/media || true
+          curl -vL -u "admin:$APP_PASS" http://localhost:8880/wp-json/wp/v2/media/ || true
           exit 1
 
       - name: Upload test images

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,21 +104,22 @@ jobs:
               --skip-email
 
             # Pretty permalinks are required for /wp-json/ REST API routing.
-            wp rewrite structure '/%postname%/' \
+            wp rewrite structure "/%postname%/" \
               --path=/var/www/html --allow-root
             wp rewrite flush --hard \
               --path=/var/www/html --allow-root
-
-            # Apache strips the Authorization header before PHP sees it in some
-            # configurations. This rewrite rule passes it through explicitly so
-            # WordPress Application Password auth works over HTTP.
-            sed -i '/RewriteEngine On/a RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]' \
-              /var/www/html/.htaccess
 
             APP_PASS=$(wp user application-password create admin "ci-test" \
               --porcelain --path=/var/www/html --allow-root)
             echo "APP_PASS=$APP_PASS" > /tmp/wp-test-env
           '
+          # Pass the Authorization header through Apache rewrite rules to PHP.
+          # Apache strips it in some configurations before PHP sees PHP_AUTH_USER/PW,
+          # which breaks WordPress Application Password auth. Run outside bash -c to
+          # avoid single-quote nesting issues.
+          docker exec wp-test sed -i \
+            's|RewriteEngine On|RewriteEngine On\nRewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]|' \
+            /var/www/html/.htaccess
           # Extract the app password
           docker cp wp-test:/tmp/wp-test-env /tmp/wp-test-env
           source /tmp/wp-test-env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,13 +113,18 @@ jobs:
               --porcelain --path=/var/www/html --allow-root)
             echo "APP_PASS=$APP_PASS" > /tmp/wp-test-env
           '
-          # Pass the Authorization header through Apache rewrite rules to PHP.
-          # Apache strips it in some configurations before PHP sees PHP_AUTH_USER/PW,
-          # which breaks WordPress Application Password auth. Run outside bash -c to
-          # avoid single-quote nesting issues.
+          # Keep the .htaccess rewrite-level passthrough as a fallback.
           docker exec wp-test sed -i \
             's|RewriteEngine On|RewriteEngine On\nRewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]|' \
             /var/www/html/.htaccess
+          # The definitive fix: add a SetEnvIf directive at the Apache config level.
+          # mod_php should populate PHP_AUTH_USER/PW automatically, but in some Docker
+          # Apache builds it does not. SetEnvIf copies the header into an env var that
+          # WordPress Application Password auth reads as a fallback.
+          # Using python3 to write the file avoids all shell-quoting edge cases.
+          docker exec wp-test python3 -c "open('/etc/apache2/conf-available/auth-pass.conf','w').write('SetEnvIf Authorization \"(.*)\" HTTP_AUTHORIZATION=\$1\n')"
+          docker exec wp-test a2enconf auth-pass
+          docker exec wp-test apache2ctl graceful
           # Extract the app password
           docker cp wp-test:/tmp/wp-test-env /tmp/wp-test-env
           source /tmp/wp-test-env
@@ -137,14 +142,26 @@ jobs:
               | grep -i "^content-type" | tail -1)
             if echo "$CT" | grep -qi "application/json"; then
               echo "REST API is ready (JSON response confirmed)"
-              exit 0
+              break
             fi
             echo "content-type: ${CT:-none}, retrying ($i/20)..."
             sleep 3
           done
-          echo "ERROR: REST API never returned JSON"
-          curl -vL -u "admin:$APP_PASS" http://localhost:8880/wp-json/wp/v2/media/ || true
-          exit 1
+          if ! echo "$CT" | grep -qi "application/json"; then
+            echo "ERROR: REST API never returned JSON"
+            curl -vL -u "admin:$APP_PASS" http://localhost:8880/wp-json/wp/v2/media/ || true
+            exit 1
+          fi
+          echo "Verifying authenticated write access (/users/me requires auth)..."
+          ME_STATUS=$(curl -sL -o /dev/null -w "%{http_code}" \
+            -u "admin:$APP_PASS" \
+            http://localhost:8880/wp-json/wp/v2/users/me)
+          if [ "$ME_STATUS" != "200" ]; then
+            echo "ERROR: Auth check failed — /users/me returned $ME_STATUS (expected 200)"
+            curl -sL -u "admin:$APP_PASS" http://localhost:8880/wp-json/wp/v2/users/me | head -c 500
+            exit 1
+          fi
+          echo "Auth check: OK (HTTP $ME_STATUS)"
 
       - name: Debug REST API response
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,12 @@ jobs:
               --allow-root \
               --skip-email
 
+            # Pretty permalinks are required for /wp-json/ REST API routing.
+            wp rewrite structure '/%postname%/' \
+              --path=/var/www/html --allow-root
+            wp rewrite flush --hard \
+              --path=/var/www/html --allow-root
+
             APP_PASS=$(wp user application-password create admin "ci-test" \
               --porcelain --path=/var/www/html --allow-root)
             echo "APP_PASS=$APP_PASS" > /tmp/wp-test-env
@@ -117,19 +123,19 @@ jobs:
       - name: Verify WordPress REST API
         run: |
           source /tmp/wp-test-env
-          echo "Polling REST API until ready..."
+          echo "Polling REST API until it returns JSON..."
           for i in $(seq 1 20); do
-            STATUS=$(curl -sL -o /dev/null -w "%{http_code}" \
-              -u "admin:$APP_PASS" \
-              http://localhost:8880/wp-json/wp/v2/media/)
-            if [ "$STATUS" = "200" ]; then
-              echo "REST API is ready (HTTP $STATUS)"
+            CT=$(curl -sIL -u "admin:$APP_PASS" \
+              http://localhost:8880/wp-json/wp/v2/media/ 2>/dev/null \
+              | grep -i "^content-type" | tail -1)
+            if echo "$CT" | grep -qi "application/json"; then
+              echo "REST API is ready (JSON response confirmed)"
               exit 0
             fi
-            echo "REST API returned $STATUS, retrying ($i/20)..."
+            echo "content-type: ${CT:-none}, retrying ($i/20)..."
             sleep 3
           done
-          echo "ERROR: REST API never became ready"
+          echo "ERROR: REST API never returned JSON"
           curl -vL -u "admin:$APP_PASS" http://localhost:8880/wp-json/wp/v2/media/ || true
           exit 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,10 @@ jobs:
           # mod_php should populate PHP_AUTH_USER/PW automatically, but in some Docker
           # Apache builds it does not. SetEnvIf copies the header into an env var that
           # WordPress Application Password auth reads as a fallback.
-          # Using python3 to write the file avoids all shell-quoting edge cases.
-          docker exec wp-test python3 -c "open('/etc/apache2/conf-available/auth-pass.conf','w').write('SetEnvIf Authorization \"(.*)\" HTTP_AUTHORIZATION=\$1\n')"
+          # Use docker exec -i + heredoc to write the file — no quoting issues.
+          docker exec -i wp-test tee /etc/apache2/conf-available/auth-pass.conf << 'APACHEEOF'
+SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+APACHEEOF
           docker exec wp-test a2enconf auth-pass
           docker exec wp-test apache2ctl graceful
           # Extract the app password

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,14 @@ jobs:
           curl -vL -u "admin:$APP_PASS" http://localhost:8880/wp-json/wp/v2/media/ || true
           exit 1
 
+      - name: Debug REST API response
+        run: |
+          source /tmp/wp-test-env
+          echo "=== Headers + body for media endpoint (with query params, no trailing slash) ==="
+          curl -sLD - -u "admin:$APP_PASS" \
+            "http://localhost:8880/wp-json/wp/v2/media?per_page=1&page=1&orderby=date&order=desc" \
+            2>&1 | head -60
+
       - name: Upload test images
         run: |
           docker exec wp-test bash -c '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,14 +72,17 @@ jobs:
 
       - name: Wait for WordPress
         run: |
+          echo "Waiting for Apache to start..."
           for i in $(seq 1 30); do
             if curl -sf http://localhost:8880/wp-login.php > /dev/null 2>&1; then
-              echo "WordPress is ready"
-              break
+              echo "Apache is ready"
+              exit 0
             fi
-            echo "Waiting for WordPress... ($i/30)"
+            echo "Waiting... ($i/30)"
             sleep 5
           done
+          echo "ERROR: Apache never became ready"
+          exit 1
 
       - name: Setup WordPress
         run: |
@@ -89,8 +92,9 @@ jobs:
             chmod +x wp-cli.phar
             mv wp-cli.phar /usr/local/bin/wp
 
+            # URL must match the host:port that tests will use (stored in WP db)
             wp core install \
-              --url="http://localhost:80" \
+              --url="http://localhost:8880" \
               --title="localpress CI" \
               --admin_user=admin \
               --admin_password=admin123 \
@@ -109,6 +113,25 @@ jobs:
           echo "WP_TEST_APP_PASSWORD=$APP_PASS" >> $GITHUB_ENV
           echo "WP_TEST_URL=http://localhost:8880" >> $GITHUB_ENV
           echo "WP_TEST_USER=admin" >> $GITHUB_ENV
+
+      - name: Verify WordPress REST API
+        run: |
+          source /tmp/wp-test-env
+          echo "Polling REST API until ready..."
+          for i in $(seq 1 20); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              -u "admin:$APP_PASS" \
+              http://localhost:8880/wp-json/wp/v2/media)
+            if [ "$STATUS" = "200" ]; then
+              echo "REST API is ready (HTTP $STATUS)"
+              exit 0
+            fi
+            echo "REST API returned $STATUS, retrying ($i/20)..."
+            sleep 3
+          done
+          echo "ERROR: REST API never became ready"
+          curl -v -u "admin:$APP_PASS" http://localhost:8880/wp-json/wp/v2/media || true
+          exit 1
 
       - name: Upload test images
         run: |

--- a/src/adapters/rest.ts
+++ b/src/adapters/rest.ts
@@ -100,7 +100,15 @@ export class RestAdapter implements WpBackend {
       );
     }
 
-    const data = (await response.json()) as T;
+    const text = await response.text();
+    let data: T;
+    try {
+      data = JSON.parse(text) as T;
+    } catch {
+      throw new Error(
+        `WordPress REST API: expected JSON but got ${response.status} ${response.headers.get('content-type') ?? 'unknown content-type'} (${init?.method ?? 'GET'} ${response.url})\nBody: ${text.slice(0, 500)}`,
+      );
+    }
     return { data, headers: response.headers };
   }
 

--- a/src/adapters/rest.ts
+++ b/src/adapters/rest.ts
@@ -9,16 +9,16 @@
 
 import type { SiteConfig } from '../types.ts';
 import type {
-    Capability,
-    ListFilters,
-    MediaItem,
-    MediaSize,
-    PruneResult,
-    Reference,
-    ReferenceScope,
-    UpdateMetadata,
-    UploadMetadata,
-    WpBackend,
+  Capability,
+  ListFilters,
+  MediaItem,
+  MediaSize,
+  PruneResult,
+  Reference,
+  ReferenceScope,
+  UpdateMetadata,
+  UploadMetadata,
+  WpBackend,
 } from './types.ts';
 import { CapabilityUnavailableError } from './types.ts';
 
@@ -74,7 +74,10 @@ export class RestAdapter implements WpBackend {
     return data;
   }
 
-  private async requestRaw<T>(url: string, init?: RequestInit): Promise<{ data: T; headers: Headers }> {
+  private async requestRaw<T>(
+    url: string,
+    init?: RequestInit,
+  ): Promise<{ data: T; headers: Headers }> {
     const response = await fetch(url, {
       ...init,
       headers: {
@@ -93,13 +96,11 @@ export class RestAdapter implements WpBackend {
         wpMessage = body.slice(0, 200);
       }
       throw new Error(
-        `WordPress REST API error: ${response.status} ${response.statusText}` +
-          (wpMessage ? ` — ${wpMessage}` : '') +
-          ` (${init?.method ?? 'GET'} ${url})`,
+        `WordPress REST API error: ${response.status} ${response.statusText}${wpMessage ? ` — ${wpMessage}` : ''} (${init?.method ?? 'GET'} ${url})`,
       );
     }
 
-    const data = await response.json() as T;
+    const data = (await response.json()) as T;
     return { data, headers: response.headers };
   }
 
@@ -126,9 +127,11 @@ export class RestAdapter implements WpBackend {
     };
 
     applyCommonFilters(params, filters);
-    const { data, headers } = await this.requestRaw<WpMediaResponse[]>(this.apiUrl('/media', params));
-    const total = parseInt(headers.get('X-WP-Total') ?? '0', 10);
-    const totalPages = parseInt(headers.get('X-WP-TotalPages') ?? '1', 10);
+    const { data, headers } = await this.requestRaw<WpMediaResponse[]>(
+      this.apiUrl('/media', params),
+    );
+    const total = Number.parseInt(headers.get('X-WP-Total') ?? '0', 10);
+    const totalPages = Number.parseInt(headers.get('X-WP-TotalPages') ?? '1', 10);
     const items = applySizeSort(data.map(mapWpMediaToItem), filters);
     return { items, total, totalPages };
   }
@@ -285,7 +288,7 @@ export class RestAdapter implements WpBackend {
    */
   private async paginateAll<T>(firstPageUrl: string): Promise<T[]> {
     const results: T[] = [];
-    let url: string | null = firstPageUrl;
+    const url: string | null = firstPageUrl;
     let page = 1;
 
     while (url) {

--- a/src/adapters/wp-cli.ts
+++ b/src/adapters/wp-cli.ts
@@ -11,15 +11,15 @@ import { join } from 'node:path';
 import type { SiteConfig, SshConfig } from '../types.ts';
 import { scpUpload, sshExec } from './ssh.ts';
 import type {
-    Capability,
-    ListFilters,
-    MediaItem,
-    PruneResult,
-    Reference,
-    ReferenceScope,
-    UpdateMetadata,
-    UploadMetadata,
-    WpBackend,
+  Capability,
+  ListFilters,
+  MediaItem,
+  PruneResult,
+  Reference,
+  ReferenceScope,
+  UpdateMetadata,
+  UploadMetadata,
+  WpBackend,
 } from './types.ts';
 
 const WP_CLI_CAPABILITIES: ReadonlySet<Capability> = new Set<Capability>([
@@ -57,9 +57,7 @@ export class WpCliAdapter implements WpBackend {
     const result = await sshExec(this.ssh, fullCommand);
 
     if (result.exitCode !== 0) {
-      throw new Error(
-        `WP-CLI error (exit ${result.exitCode}): ${result.stderr || result.stdout}`,
-      );
+      throw new Error(`WP-CLI error (exit ${result.exitCode}): ${result.stderr || result.stdout}`);
     }
 
     return result.stdout;
@@ -199,9 +197,7 @@ export class WpCliAdapter implements WpBackend {
 
   async replaceInPlace(id: number, file: Buffer): Promise<MediaItem> {
     // Get the current attachment's file path on the server.
-    const currentFile = await this.wp(
-      `post meta get ${id} _wp_attached_file`,
-    );
+    const currentFile = await this.wp(`post meta get ${id} _wp_attached_file`);
     const uploadsDir = await this.wp(
       `eval 'echo wp_upload_dir()["basedir"];' 2>/dev/null || echo "/var/www/html/wp-content/uploads"`,
     );
@@ -260,9 +256,7 @@ export class WpCliAdapter implements WpBackend {
 
   async pruneOrphans(): Promise<PruneResult> {
     // Get the uploads directory.
-    const uploadsDir = await this.wp(
-      `eval 'echo wp_upload_dir()["basedir"];'`,
-    );
+    const uploadsDir = await this.wp(`eval 'echo wp_upload_dir()["basedir"];'`);
 
     // List all files in uploads.
     const filesOutput = await sshExec(
@@ -319,7 +313,7 @@ export class WpCliAdapter implements WpBackend {
     // Find missing: attachments in DB whose file is gone.
     const missingFiles: number[] = [];
     const attachmentsOutput = await this.wp(
-      `post list --post_type=attachment --post_status=inherit --fields=ID --format=json`,
+      'post list --post_type=attachment --post_status=inherit --fields=ID --format=json',
     );
     const attachments = JSON.parse(attachmentsOutput) as Array<{ ID: number }>;
 
@@ -327,7 +321,10 @@ export class WpCliAdapter implements WpBackend {
       try {
         const filePath = await this.wp(`post meta get ${att.ID} _wp_attached_file`);
         const fullPath = `${uploadsDir.trim()}/${filePath.trim()}`;
-        const existsResult = await sshExec(this.ssh, `test -f "${fullPath}" && echo "yes" || echo "no"`);
+        const existsResult = await sshExec(
+          this.ssh,
+          `test -f "${fullPath}" && echo "yes" || echo "no"`,
+        );
         if (existsResult.stdout.trim() === 'no') {
           missingFiles.push(att.ID);
         }

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -63,14 +63,8 @@ export function registerAuditCommand(program: Command): void {
       '--display-size',
       'flag images significantly larger than their largest registered WP thumbnail size',
     )
-    .option(
-      '--duplicates',
-      'flag perceptually identical or near-identical images (requires sharp)',
-    )
-    .option(
-      '--broken-refs',
-      'flag attachment URLs referenced in post content that return 404',
-    )
+    .option('--duplicates', 'flag perceptually identical or near-identical images (requires sharp)')
+    .option('--broken-refs', 'flag attachment URLs referenced in post content that return 404')
     .action(async (options) => {
       const parentOpts = program.opts();
       const config = await loadConfig();
@@ -325,9 +319,7 @@ interface SizeEntry {
   height: number;
 }
 
-function findLargestRegisteredSize(
-  sizes: NonNullable<MediaItem['sizes']>,
-): SizeEntry | null {
+function findLargestRegisteredSize(sizes: NonNullable<MediaItem['sizes']>): SizeEntry | null {
   let largest: SizeEntry | null = null;
   for (const [name, size] of Object.entries(sizes)) {
     if (name === 'full') continue; // 'full' is the source itself
@@ -368,11 +360,7 @@ async function detectDuplicates(items: MediaItem[]): Promise<AuditFinding[]> {
       const buffer = Buffer.from(await response.arrayBuffer());
 
       // Resize to 9×8 grayscale for dHash computation.
-      const pixels = await sharp(buffer)
-        .resize(9, 8, { fit: 'fill' })
-        .grayscale()
-        .raw()
-        .toBuffer();
+      const pixels = await sharp(buffer).resize(9, 8, { fit: 'fill' }).grayscale().raw().toBuffer();
 
       let hash = 0n;
       for (let row = 0; row < 8; row++) {

--- a/src/cli/commands/caption.ts
+++ b/src/cli/commands/caption.ts
@@ -48,7 +48,9 @@ export function registerCaptionCommand(program: Command): void {
       // --list-models
       if (options.listModels) {
         if (!(await isOllamaAvailable(options.ollamaUrl))) {
-          error(`Ollama is not running at ${options.ollamaUrl}.\nStart it with: ollama serve`);
+          error(
+            `Ollama is not running at ${options.ollamaUrl}.\n\n  Start it:     ollama serve\n  Setup guide:  https://localpress.griffen.codes/docs/ollama-setup`,
+          );
           process.exit(2);
         }
         const models = await listOllamaModels(options.ollamaUrl);
@@ -68,16 +70,14 @@ export function registerCaptionCommand(program: Command): void {
         for (const m of list) {
           info(`  ${m.name.padEnd(30)} ${formatBytes(m.size)}`);
         }
-        info(`\nPull a model: ollama pull moondream`);
+        info('\nPull a model: ollama pull moondream');
         return;
       }
 
       // Validate Ollama is reachable before doing any work.
       if (!(await isOllamaAvailable(options.ollamaUrl))) {
         error(
-          `Ollama is not running at ${options.ollamaUrl}.\n` +
-            'Start it with: ollama serve\n' +
-            `Then pull a vision model: ollama pull ${options.model}`,
+          `Ollama is not running at ${options.ollamaUrl}.\n\n  Start it:       ollama serve\n  Pull a model:   ollama pull ${options.model}\n\n  Setup guide:    https://localpress.griffen.codes/docs/ollama-setup`,
         );
         process.exit(2);
       }
@@ -141,7 +141,9 @@ export function registerCaptionCommand(program: Command): void {
 
           // Skip if alt text already set and --overwrite not passed.
           if (item.altText?.trim() && !options.overwrite) {
-            info(`  — #${id} (${item.filename}) already has alt text — skipping. (use --overwrite to replace)`);
+            info(
+              `  — #${id} (${item.filename}) already has alt text — skipping. (use --overwrite to replace)`,
+            );
             results.push({
               id,
               filename: item.filename,
@@ -188,7 +190,10 @@ export function registerCaptionCommand(program: Command): void {
               siteName: site.name,
               wpId: item.id,
               operation: 'caption',
-              paramsJson: JSON.stringify({ model: result.model, overwrite: options.overwrite ?? false }),
+              paramsJson: JSON.stringify({
+                model: result.model,
+                overwrite: options.overwrite ?? false,
+              }),
               sourceHash: null,
               resultHash: null,
               bytesBefore: null,
@@ -248,7 +253,9 @@ export function registerCaptionCommand(program: Command): void {
       const acted = results.filter((r) => !r.skipped);
       if (acted.length > 0 || failures > 0) {
         const dryNote = options.dryRun ? ' (dry run — WordPress not updated)' : '';
-        info(`\n  Done: ${acted.length} captioned, ${results.filter((r) => r.skipped).length} skipped, ${failures} failed${dryNote}.`);
+        info(
+          `\n  Done: ${acted.length} captioned, ${results.filter((r) => r.skipped).length} skipped, ${failures} failed${dryNote}.`,
+        );
       }
 
       if (failures > 0) process.exit(1);

--- a/src/cli/commands/caption.ts
+++ b/src/cli/commands/caption.ts
@@ -1,0 +1,275 @@
+/**
+ * `localpress caption [ids...]` — AI alt-text generation via local Ollama.
+ *
+ * Downloads each attachment, sends the image to a locally-running Ollama
+ * multimodal model, and writes the result back to WordPress as alt_text.
+ * No cloud API. No credits.
+ *
+ * Recommended models (install via `ollama pull <name>`):
+ *   moondream   ~1.7 GB  fast, accurate, ideal for bulk alt-text
+ *   llava       ~4.7 GB  higher quality, slower
+ */
+
+import type { Command } from 'commander';
+import { AdapterResolver } from '../../adapters/resolver.ts';
+import {
+  DEFAULT_OLLAMA_MODEL,
+  DEFAULT_OLLAMA_URL,
+  generateCaption,
+  isOllamaAvailable,
+  listOllamaModels,
+} from '../../engine/caption/ollama.ts';
+import { SiteDb } from '../../engine/state/db.ts';
+import { getSiteDbPath, loadConfig, resolveActiveSite } from '../utils/config.ts';
+import { error, info, printJson, warn } from '../utils/output.ts';
+
+export function registerCaptionCommand(program: Command): void {
+  program
+    .command('caption [ids...]')
+    .description('Generate alt-text for images using a local Ollama vision model')
+    .option(
+      '--model <name>',
+      `Ollama vision model to use (default: ${DEFAULT_OLLAMA_MODEL})`,
+      DEFAULT_OLLAMA_MODEL,
+    )
+    .option('--prompt <text>', 'custom captioning prompt')
+    .option(
+      '--ollama-url <url>',
+      `Ollama base URL (default: ${DEFAULT_OLLAMA_URL})`,
+      DEFAULT_OLLAMA_URL,
+    )
+    .option('--missing-alt', 'only process attachments that have no alt text set')
+    .option('--overwrite', 'replace existing alt text (default: skip if already set)')
+    .option('--dry-run', 'print generated captions without updating WordPress')
+    .option('--list-models', 'list Ollama models available locally and exit')
+    .action(async (idStrs: string[], options) => {
+      const parentOpts = program.opts();
+
+      // --list-models
+      if (options.listModels) {
+        if (!(await isOllamaAvailable(options.ollamaUrl))) {
+          error(`Ollama is not running at ${options.ollamaUrl}.\nStart it with: ollama serve`);
+          process.exit(2);
+        }
+        const models = await listOllamaModels(options.ollamaUrl);
+        const vision = models.filter((m) =>
+          /moondream|llava|bakllava|llama.*vision|qwen.*vl|minicpm|phi.*vision/i.test(m.name),
+        );
+        if (parentOpts.json) {
+          printJson(vision.length ? vision : models);
+          return;
+        }
+        const list = vision.length ? vision : models;
+        if (list.length === 0) {
+          info('No models found. Pull one with: ollama pull moondream');
+          return;
+        }
+        info('Locally available vision models:\n');
+        for (const m of list) {
+          info(`  ${m.name.padEnd(30)} ${formatBytes(m.size)}`);
+        }
+        info(`\nPull a model: ollama pull moondream`);
+        return;
+      }
+
+      // Validate Ollama is reachable before doing any work.
+      if (!(await isOllamaAvailable(options.ollamaUrl))) {
+        error(
+          `Ollama is not running at ${options.ollamaUrl}.\n` +
+            'Start it with: ollama serve\n' +
+            `Then pull a vision model: ollama pull ${options.model}`,
+        );
+        process.exit(2);
+      }
+
+      const config = await loadConfig();
+      const site = resolveActiveSite(config, parentOpts.site);
+      const resolver = new AdapterResolver(site);
+      const listAdapter = resolver.resolve('list');
+      const getAdapter = resolver.resolve('get');
+      const updateAdapter = resolver.resolve('update-meta');
+
+      // Resolve which attachment IDs to process.
+      let ids: number[];
+
+      if (idStrs.length > 0) {
+        ids = idStrs.map((s) => Number.parseInt(s, 10));
+        if (ids.some(Number.isNaN)) {
+          error('All arguments must be valid attachment IDs (integers).');
+          process.exit(2);
+        }
+      } else if (options.missingAlt) {
+        info('  Fetching attachments with missing alt text…');
+        const allItems = await fetchAllImageAttachments(listAdapter);
+        ids = allItems.filter((item) => !item.altText?.trim()).map((item) => item.id);
+        if (ids.length === 0) {
+          info('All image attachments already have alt text.');
+          return;
+        }
+        info(`  Found ${ids.length} attachment(s) without alt text.\n`);
+      } else {
+        error(
+          'Specify attachment IDs or use --missing-alt to target items without alt text.\n' +
+            'Example: localpress caption 123 124\n' +
+            '         localpress caption --missing-alt',
+        );
+        process.exit(2);
+      }
+
+      const db = SiteDb.init(getSiteDbPath(site.name));
+      db.ensureSite(site.name, site.url);
+
+      const results: Array<{
+        id: number;
+        filename: string;
+        caption: string;
+        previousAlt: string | undefined;
+        skipped: boolean;
+        durationMs: number;
+      }> = [];
+      let failures = 0;
+
+      for (const id of ids) {
+        const startTime = Date.now();
+        try {
+          const item = await getAdapter.getMedia(id);
+
+          if (!item.mimeType.startsWith('image/')) {
+            warn(`  ⚠ #${id} (${item.filename}) is not an image — skipping.`);
+            continue;
+          }
+
+          // Skip if alt text already set and --overwrite not passed.
+          if (item.altText?.trim() && !options.overwrite) {
+            info(`  — #${id} (${item.filename}) already has alt text — skipping. (use --overwrite to replace)`);
+            results.push({
+              id,
+              filename: item.filename,
+              caption: item.altText,
+              previousAlt: item.altText,
+              skipped: true,
+              durationMs: 0,
+            });
+            continue;
+          }
+
+          info(`  Captioning #${id} (${item.filename})…`);
+
+          const response = await fetch(item.url);
+          if (!response.ok) throw new Error(`Failed to download image: ${response.status}`);
+          const imageBuffer = Buffer.from(await response.arrayBuffer());
+
+          const result = await generateCaption(imageBuffer, {
+            model: options.model,
+            prompt: options.prompt,
+            ollamaUrl: options.ollamaUrl,
+          });
+
+          info(`    ✓ "${result.caption}" (${result.durationMs}ms)`);
+
+          if (!options.dryRun) {
+            await updateAdapter.updateMetadata(id, { altText: result.caption });
+          }
+
+          db.upsertAttachment({
+            siteName: site.name,
+            wpId: item.id,
+            sourceUrl: item.url,
+            sourceHash: null,
+            sizeBytes: imageBuffer.length,
+            width: item.width ?? null,
+            height: item.height ?? null,
+            mimeType: item.mimeType,
+            lastSeenAt: Date.now(),
+          });
+
+          if (!options.dryRun) {
+            db.recordProcessing({
+              siteName: site.name,
+              wpId: item.id,
+              operation: 'caption',
+              paramsJson: JSON.stringify({ model: result.model, overwrite: options.overwrite ?? false }),
+              sourceHash: null,
+              resultHash: null,
+              bytesBefore: null,
+              bytesAfter: null,
+              resultWpId: null,
+              ranAt: Date.now(),
+              durationMs: result.durationMs,
+              status: 'success',
+              errorMessage: null,
+            });
+          }
+
+          results.push({
+            id,
+            filename: item.filename,
+            caption: result.caption,
+            previousAlt: item.altText ?? undefined,
+            skipped: false,
+            durationMs: result.durationMs,
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          error(`    ✗ #${id}: ${message}`);
+          failures++;
+
+          db.recordProcessing({
+            siteName: site.name,
+            wpId: id,
+            operation: 'caption',
+            paramsJson: JSON.stringify({ model: options.model }),
+            sourceHash: null,
+            resultHash: null,
+            bytesBefore: null,
+            bytesAfter: null,
+            resultWpId: null,
+            ranAt: Date.now(),
+            durationMs: Date.now() - startTime,
+            status: 'failure',
+            errorMessage: message,
+          });
+        }
+      }
+
+      db.close();
+
+      if (parentOpts.json) {
+        printJson({
+          dryRun: options.dryRun ?? false,
+          processed: results.filter((r) => !r.skipped).length,
+          skipped: results.filter((r) => r.skipped).length,
+          failures,
+          results,
+        });
+        return;
+      }
+
+      const acted = results.filter((r) => !r.skipped);
+      if (acted.length > 0 || failures > 0) {
+        const dryNote = options.dryRun ? ' (dry run — WordPress not updated)' : '';
+        info(`\n  Done: ${acted.length} captioned, ${results.filter((r) => r.skipped).length} skipped, ${failures} failed${dryNote}.`);
+      }
+
+      if (failures > 0) process.exit(1);
+    });
+}
+
+async function fetchAllImageAttachments(
+  adapter: import('../../adapters/types.ts').WpBackend,
+): Promise<import('../../adapters/types.ts').MediaItem[]> {
+  const all: import('../../adapters/types.ts').MediaItem[] = [];
+  let page = 1;
+  while (true) {
+    const result = await adapter.listMediaPage({ type: 'image/', perPage: 100, page });
+    all.push(...result.items);
+    if (page >= result.totalPages) break;
+    page++;
+  }
+  return all;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(0)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -167,7 +167,9 @@ export function registerConfigCommand(program: Command): void {
       const profile = config.profiles?.[name];
 
       if (!profile) {
-        error(`Profile '${name}' not found. Run \`localpress config list-profiles\` to see available profiles.`);
+        error(
+          `Profile '${name}' not found. Run \`localpress config list-profiles\` to see available profiles.`,
+        );
         process.exit(2);
       }
 
@@ -225,7 +227,7 @@ export function registerConfigCommand(program: Command): void {
         process.exit(2);
       }
 
-      delete config.profiles![name];
+      delete config.profiles?.[name];
       await saveConfig(config);
 
       if (parentOpts.json) {

--- a/src/cli/commands/convert.ts
+++ b/src/cli/commands/convert.ts
@@ -22,9 +22,7 @@ export function registerConvertCommand(program: Command): void {
     .command('convert <ids...>')
     .description('Convert attachments to a different format (webp, avif, jpeg, png)')
     .requiredOption('--to <format>', 'target format: webp, avif, jpeg, or png')
-    .option('--quality <n>', 'quality value 0-100 (codec-specific)', (v) =>
-      Number.parseInt(v, 10),
-    )
+    .option('--quality <n>', 'quality value 0-100 (codec-specific)', (v) => Number.parseInt(v, 10))
     .option('--keep-original', 'upload as a new attachment instead of replacing')
     .action(async (idStrs: string[], options) => {
       const parentOpts = program.opts();
@@ -49,7 +47,13 @@ export function registerConvertCommand(program: Command): void {
       const db = SiteDb.init(getSiteDbPath(site.name));
       db.ensureSite(site.name, site.url);
 
-      const results: Array<{ id: number; filename: string; from: string; to: string; savedBytes: number }> = [];
+      const results: Array<{
+        id: number;
+        filename: string;
+        from: string;
+        to: string;
+        savedBytes: number;
+      }> = [];
       let failures = 0;
 
       for (const id of ids) {
@@ -105,7 +109,9 @@ export function registerConvertCommand(program: Command): void {
             });
             resultWpId = uploaded.id;
             if (!options.keepOriginal) {
-              warn(`    ⚠ Uploaded as new attachment #${resultWpId} (in-place replacement not available).`);
+              warn(
+                `    ⚠ Uploaded as new attachment #${resultWpId} (in-place replacement not available).`,
+              );
             }
           }
 
@@ -162,7 +168,9 @@ export function registerConvertCommand(program: Command): void {
         printJson({ converted: results.length, failures, results });
       } else if (results.length > 0) {
         const totalSaved = results.reduce((sum, r) => sum + r.savedBytes, 0);
-        info(`\n  Done: ${results.length} converted, ${failures} failed. Saved ${formatBytes(totalSaved)}.`);
+        info(
+          `\n  Done: ${results.length} converted, ${failures} failed. Saved ${formatBytes(totalSaved)}.`,
+        );
       }
 
       if (failures > 0) process.exit(1);

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -47,7 +47,8 @@ const KNOWN_PLUGINS: Array<{
     slug: 'wp-smush-pro',
     name: 'Smush Pro',
     capability: 'conflict awareness',
-    description: 'Smush may re-process images after localpress uploads — consider disabling auto-smush',
+    description:
+      'Smush may re-process images after localpress uploads — consider disabling auto-smush',
   },
   {
     slug: 'shortpixel-image-optimiser',
@@ -145,8 +146,9 @@ export function registerDoctorCommand(program: Command): void {
         if (!availability.wpCli) {
           issues.push({
             severity: 'info',
-            message: 'WP-CLI (SSH) not configured — replace-in-place and full reference scanning unavailable',
-            fix: 'Run `localpress init --site ' + name + '` and add SSH config to unlock these capabilities',
+            message:
+              'WP-CLI (SSH) not configured — replace-in-place and full reference scanning unavailable',
+            fix: `Run \`localpress init --site ${name}\` and add SSH config to unlock these capabilities`,
           });
         }
 
@@ -160,9 +162,7 @@ export function registerDoctorCommand(program: Command): void {
         const conflictPlugins = plugins.filter(
           (p) =>
             p.active &&
-            ['wp-smush-pro', 'shortpixel-image-optimiser', 'ewww-image-optimizer'].includes(
-              p.slug,
-            ),
+            ['wp-smush-pro', 'shortpixel-image-optimiser', 'ewww-image-optimizer'].includes(p.slug),
         );
         for (const p of conflictPlugins) {
           issues.push({
@@ -241,7 +241,8 @@ export function registerDoctorCommand(program: Command): void {
             info('');
             info('  Issues:');
             for (const issue of issues) {
-              const icon = issue.severity === 'error' ? '✗' : issue.severity === 'warning' ? '⚠' : 'ℹ';
+              const icon =
+                issue.severity === 'error' ? '✗' : issue.severity === 'warning' ? '⚠' : 'ℹ';
               info(`    ${icon} ${issue.message}`);
               if (issue.fix) {
                 info(`      → ${issue.fix}`);
@@ -302,7 +303,7 @@ async function detectPlugins(site: SiteConfig): Promise<PluginStatus[]> {
   return KNOWN_PLUGINS.map((known) => {
     const installed = rawPlugins.find(
       (p) =>
-        p.plugin.startsWith(known.slug + '/') ||
+        p.plugin.startsWith(`${known.slug}/`) ||
         p.plugin === known.slug ||
         p.name.toLowerCase().includes(known.name.toLowerCase()),
     );
@@ -310,7 +311,9 @@ async function detectPlugins(site: SiteConfig): Promise<PluginStatus[]> {
     return {
       slug: known.slug,
       name: known.name,
-      active: installed ? installed.status === 'active' || installed.status === 'network-active' : false,
+      active: installed
+        ? installed.status === 'active' || installed.status === 'network-active'
+        : false,
       capability: known.capability,
       description: known.description,
       version: installed?.version,

--- a/src/cli/commands/edit.ts
+++ b/src/cli/commands/edit.ts
@@ -50,7 +50,7 @@ export function registerEditCommand(program: Command): void {
       const getAdapter = resolver.resolve('get');
 
       // 1. Fetch attachment metadata.
-      let item;
+      let item: import('../../adapters/types.ts').MediaItem;
       try {
         item = await getAdapter.getMedia(id);
       } catch (err) {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -54,8 +54,8 @@ export function registerInitCommand(program: Command): void {
 
       // Non-interactive path (flags required).
       let siteUrl = options.url as string | undefined;
-      let username = options.username as string | undefined;
-      let appPassword = options.appPassword as string | undefined;
+      const username = options.username as string | undefined;
+      const appPassword = options.appPassword as string | undefined;
       let siteName = options.name as string | undefined;
 
       if (!siteUrl || !username || !appPassword) {
@@ -91,8 +91,7 @@ export function registerInitCommand(program: Command): void {
         if (!response.ok) {
           if (response.status === 401) {
             error(
-              'Authentication failed. Check your username and Application Password.\n' +
-                `Application Passwords: ${siteUrl}/wp-admin/profile.php`,
+              `Authentication failed. Check your username and Application Password.\nApplication Passwords: ${siteUrl}/wp-admin/profile.php`,
             );
           } else {
             error(`Connection failed: ${response.status} ${response.statusText}`);
@@ -103,7 +102,9 @@ export function registerInitCommand(program: Command): void {
         const user = (await response.json()) as { name?: string; slug?: string };
         info(`  ✓ Authenticated as ${user.name ?? user.slug ?? username}`);
       } catch (err) {
-        error(`Could not connect to ${siteUrl}: ${err instanceof Error ? err.message : String(err)}`);
+        error(
+          `Could not connect to ${siteUrl}: ${err instanceof Error ? err.message : String(err)}`,
+        );
         process.exit(4);
       }
 

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -9,9 +9,9 @@
 import type { Command } from 'commander';
 import { AdapterResolver } from '../../adapters/resolver.ts';
 import type { ListFilters, MediaItem, SortField, SortOrder } from '../../adapters/types.ts';
-import type { MediaBrowserAction } from '../components/MediaBrowser.tsx';
 import { SiteDb } from '../../engine/state/db.ts';
-import { loadConfig, getSiteDbPath, resolveActiveSite } from '../utils/config.ts';
+import type { MediaBrowserAction } from '../components/MediaBrowser.tsx';
+import { getSiteDbPath, loadConfig, resolveActiveSite } from '../utils/config.ts';
 import { error, info, printJson } from '../utils/output.ts';
 
 export function registerListCommand(program: Command): void {
@@ -48,7 +48,9 @@ export function registerListCommand(program: Command): void {
         perPage: Math.min(options.limit ?? 50, 100),
         page: options.page ?? 1,
         sortBy: VALID_SORT_FIELDS.includes(options.sort) ? (options.sort as SortField) : undefined,
-        sortOrder: VALID_SORT_ORDERS.includes(options.order) ? (options.order as SortOrder) : undefined,
+        sortOrder: VALID_SORT_ORDERS.includes(options.order)
+          ? (options.order as SortOrder)
+          : undefined,
       };
 
       // Interactive TUI mode.
@@ -78,7 +80,9 @@ export function registerListCommand(program: Command): void {
             const db = SiteDb.init(getSiteDbPath(site.name));
             processedIds = db.listProcessedWpIds(site.name);
             db.close();
-          } catch { /* DB doesn't exist yet — all items unoptimized */ }
+          } catch {
+            /* DB doesn't exist yet — all items unoptimized */
+          }
           result.items = result.items.filter((item) => !processedIds.has(item.id));
         }
 
@@ -94,7 +98,9 @@ export function registerListCommand(program: Command): void {
             processedIds,
             sortBy: filters.sortBy,
             sortOrder: filters.sortOrder,
-            onAction: (action) => { pending.action = action; },
+            onAction: (action) => {
+              pending.action = action;
+            },
             onPageChange: async (page: number) => {
               const r = await adapter.listMediaPage({ ...filters, page });
               if (options.unoptimized) {
@@ -149,7 +155,9 @@ export function registerListCommand(program: Command): void {
           const processed = db.listProcessedWpIds(site.name);
           items = items.filter((item) => !processed.has(item.id));
           db.close();
-        } catch { /* If the DB doesn't exist yet, all items are unoptimized. */ }
+        } catch {
+          /* If the DB doesn't exist yet, all items are unoptimized. */
+        }
       }
 
       if (parentOpts.json) {
@@ -167,9 +175,10 @@ export function registerListCommand(program: Command): void {
       const from = (pageNum - 1) * perPage + 1;
       const to = Math.min(from + items.length - 1, total);
       const pageInfo = totalPages > 1 ? `  (page ${pageNum}/${totalPages})` : '';
-      const sortInfo = filters.sortBy && filters.sortBy !== 'date'
-        ? `  sorted by ${filters.sortBy} ${filters.sortOrder ?? 'desc'}`
-        : '';
+      const sortInfo =
+        filters.sortBy && filters.sortBy !== 'date'
+          ? `  sorted by ${filters.sortBy} ${filters.sortOrder ?? 'desc'}`
+          : '';
       info(`Showing ${from}–${to} of ${total} item(s)${pageInfo}${sortInfo}:\n`);
 
       for (const item of items) {
@@ -179,12 +188,13 @@ export function registerListCommand(program: Command): void {
       }
 
       if (pageNum < totalPages) {
-        const sortFlags = filters.sortBy ? ` --sort ${filters.sortBy}${filters.sortOrder ? ` --order ${filters.sortOrder}` : ''}` : '';
+        const sortFlags = filters.sortBy
+          ? ` --sort ${filters.sortBy}${filters.sortOrder ? ` --order ${filters.sortOrder}` : ''}`
+          : '';
         info(`\nNext page: localpress list --page ${pageNum + 1}${sortFlags}`);
       }
     });
 }
-
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;

--- a/src/cli/commands/optimize.ts
+++ b/src/cli/commands/optimize.ts
@@ -60,7 +60,11 @@ export function registerOptimizeCommand(program: Command): void {
       'always upload as a new attachment, never attempt true replacement',
     )
     .option('--keep-original', 'do not replace; save the optimized copy as a separate attachment')
-    .option('--encoder <backend>', 'encoder: sharp (default) or jsquash (WASM codecs, better PNG via OxiPNG)', 'sharp')
+    .option(
+      '--encoder <backend>',
+      'encoder: sharp (default) or jsquash (WASM codecs, better PNG via OxiPNG)',
+      'sharp',
+    )
     .action(async (idStrs: string[], options) => {
       const parentOpts = program.opts();
       const config = await loadConfig();
@@ -246,7 +250,7 @@ export function registerOptimizeCommand(program: Command): void {
             // Upload as new attachment (fallback or --keep-original).
             const uploadAdapter = resolver.resolve('upload');
             const ext = result.after.format ? `.${result.after.format}` : '';
-            const newFilename = item.filename.replace(/\.[^.]+$/, '') + `-optimized${ext}`;
+            const newFilename = `${item.filename.replace(/\.[^.]+$/, '')}-optimized${ext}`;
             const uploaded = await uploadAdapter.upload(result.bytes, {
               filename: newFilename,
               title: item.title,

--- a/src/cli/commands/push.ts
+++ b/src/cli/commands/push.ts
@@ -63,15 +63,13 @@ export function registerPushCommand(program: Command): void {
         // Fallback: upload as new attachment.
         if (parentOpts.strict) {
           error(
-            `True in-place replacement is not available for site '${site.name}'. ` +
-              'Configure SSH for WP-CLI access, or remove --strict to allow fallback.',
+            `True in-place replacement is not available for site '${site.name}'. Configure SSH for WP-CLI access, or remove --strict to allow fallback.`,
           );
           process.exit(6);
         }
 
         warn(
-          'In-place replacement not available. Uploading as a new attachment. ' +
-            `Run \`localpress references ${options.replace}\` to see where the old attachment is used.`,
+          `In-place replacement not available. Uploading as a new attachment. Run \`localpress references ${options.replace}\` to see where the old attachment is used.`,
         );
       }
 
@@ -96,9 +94,7 @@ export function registerPushCommand(program: Command): void {
         } else {
           info(`✓ Uploaded as attachment #${result.id} (${filename}).`);
           if (options.replace) {
-            info(
-              `  ⚠ This is a new attachment, not a replacement of #${options.replace}.`,
-            );
+            info(`  ⚠ This is a new attachment, not a replacement of #${options.replace}.`);
             info(
               `  Run \`localpress references ${options.replace} --update-to ${result.id}\` to rewrite references (v0.5).`,
             );

--- a/src/cli/commands/references.ts
+++ b/src/cli/commands/references.ts
@@ -8,8 +8,8 @@
 
 import type { Command } from 'commander';
 import { AdapterResolver } from '../../adapters/resolver.ts';
-import type { ReferenceScope } from '../../adapters/types.ts';
 import { sshExec } from '../../adapters/ssh.ts';
+import type { ReferenceScope } from '../../adapters/types.ts';
 import { loadConfig, resolveActiveSite } from '../utils/config.ts';
 import { error, info, printJson, warn } from '../utils/output.ts';
 
@@ -64,7 +64,7 @@ export function registerReferencesCommand(program: Command): void {
           `cd ${site.ssh.wpPath} && wp db query "UPDATE wp_postmeta SET meta_value='${newId}' WHERE meta_key='_thumbnail_id' AND meta_value='${id}'" --allow-root`,
         );
         if (!isDryRun) {
-          info(`  ✓ Updated _thumbnail_id references.`);
+          info('  ✓ Updated _thumbnail_id references.');
         }
 
         // 2. Search-replace the old URL with the new URL in post content.
@@ -122,7 +122,7 @@ export function registerReferencesCommand(program: Command): void {
         );
       }
 
-      let references;
+      let references: import('../../adapters/types.ts').Reference[];
       try {
         references = await adapter.findReferences(id, scope);
       } catch (err) {
@@ -143,9 +143,7 @@ export function registerReferencesCommand(program: Command): void {
         for (const ref of references) {
           const occ = ref.occurrences && ref.occurrences > 1 ? ` (${ref.occurrences}×)` : '';
           const meta = ref.metaKey ? ` [meta: ${ref.metaKey}]` : '';
-          info(
-            `  ${ref.postType} #${ref.postId}  "${ref.postTitle}"  ${ref.type}${occ}${meta}`,
-          );
+          info(`  ${ref.postType} #${ref.postId}  "${ref.postTitle}"  ${ref.type}${occ}${meta}`);
         }
         info(`\n  Total: ${references.length} reference(s).`);
       }

--- a/src/cli/commands/remove-bg.ts
+++ b/src/cli/commands/remove-bg.ts
@@ -18,8 +18,8 @@ import type { ModelName } from '../../engine/rembg/models.ts';
 import { DEFAULT_MODEL, isModelCached, listAvailableModels } from '../../engine/rembg/models.ts';
 import { removeBackground } from '../../engine/rembg/remove-bg.ts';
 import {
-    isSystemRembgAvailable,
-    removeBackgroundWithSystemRembg,
+  isSystemRembgAvailable,
+  removeBackgroundWithSystemRembg,
 } from '../../engine/rembg/system-rembg.ts';
 import { SiteDb } from '../../engine/state/db.ts';
 import { getSiteDbPath, loadConfig, resolveActiveSite } from '../utils/config.ts';
@@ -31,7 +31,9 @@ export function registerRemoveBgCommand(program: Command): void {
     .description('Remove backgrounds from images using local AI (U2-Net)')
     .option(
       '--model <name>',
-      `model to use: ${listAvailableModels().map((m) => m.name).join(', ')} (default: ${DEFAULT_MODEL})`,
+      `model to use: ${listAvailableModels()
+        .map((m) => m.name)
+        .join(', ')} (default: ${DEFAULT_MODEL})`,
       DEFAULT_MODEL,
     )
     .option('--bg <color>', 'background color instead of transparency (hex, e.g. #ffffff)')

--- a/src/cli/commands/resize.ts
+++ b/src/cli/commands/resize.ts
@@ -112,7 +112,10 @@ export function registerResizeCommand(program: Command): void {
 
           if (resultWpId === null) {
             const uploadAdapter = resolver.resolve('upload');
-            const newFilename = item.filename.replace(/\.[^.]+$/, `-resized.${result.after.format}`);
+            const newFilename = item.filename.replace(
+              /\.[^.]+$/,
+              `-resized.${result.after.format}`,
+            );
             const uploaded = await uploadAdapter.upload(result.bytes, {
               filename: newFilename,
               title: item.title,
@@ -120,12 +123,16 @@ export function registerResizeCommand(program: Command): void {
             });
             resultWpId = uploaded.id;
             if (!options.keepOriginal) {
-              warn(`    ⚠ Uploaded as new attachment #${resultWpId} (in-place replacement not available).`);
+              warn(
+                `    ⚠ Uploaded as new attachment #${resultWpId} (in-place replacement not available).`,
+              );
             }
           }
 
           const saved = sourceBytes.length - result.bytes.length;
-          info(`    ✓ ${dims} → ${newDims}  ${formatBytes(sourceBytes.length)} → ${formatBytes(result.bytes.length)} (${durationMs}ms)`);
+          info(
+            `    ✓ ${dims} → ${newDims}  ${formatBytes(sourceBytes.length)} → ${formatBytes(result.bytes.length)} (${durationMs}ms)`,
+          );
 
           // Record in SQLite.
           db.upsertAttachment({

--- a/src/cli/commands/show.ts
+++ b/src/cli/commands/show.ts
@@ -6,7 +6,7 @@
 import type { Command } from 'commander';
 import { AdapterResolver } from '../../adapters/resolver.ts';
 import { SiteDb } from '../../engine/state/db.ts';
-import { loadConfig, getSiteDbPath, resolveActiveSite } from '../utils/config.ts';
+import { getSiteDbPath, loadConfig, resolveActiveSite } from '../utils/config.ts';
 import { error, info, printJson } from '../utils/output.ts';
 
 export function registerShowCommand(program: Command): void {
@@ -26,7 +26,7 @@ export function registerShowCommand(program: Command): void {
       const resolver = new AdapterResolver(site);
       const adapter = resolver.resolve('get');
 
-      let item;
+      let item: import('../../adapters/types.ts').MediaItem;
       try {
         item = await adapter.getMedia(id);
       } catch (err) {

--- a/src/cli/commands/sites.ts
+++ b/src/cli/commands/sites.ts
@@ -104,8 +104,7 @@ export function registerSitesCommand(program: Command): void {
       if (!config.sites[name]) {
         const known = Object.keys(config.sites);
         error(
-          `Unknown site '${name}'.` +
-            (known.length ? ` Known sites: ${known.join(', ')}` : ' No sites configured.'),
+          `Unknown site '${name}'.${known.length ? ` Known sites: ${known.join(', ')}` : ' No sites configured.'}`,
         );
         process.exit(3);
       }

--- a/src/cli/commands/stats.ts
+++ b/src/cli/commands/stats.ts
@@ -7,7 +7,7 @@
 
 import type { Command } from 'commander';
 import { SiteDb } from '../../engine/state/db.ts';
-import { loadConfig, getSiteDbPath, resolveActiveSite } from '../utils/config.ts';
+import { getSiteDbPath, loadConfig, resolveActiveSite } from '../utils/config.ts';
 import { error, info, printJson } from '../utils/output.ts';
 
 export function registerStatsCommand(program: Command): void {
@@ -64,21 +64,30 @@ export function registerStatsCommand(program: Command): void {
         }
 
         if (stats.totalOps === 0) {
-          info(`No processing history yet for "${site}". Run localpress optimize, convert, resize, or remove-bg to start.`);
+          info(
+            `No processing history yet for "${site}". Run localpress optimize, convert, resize, or remove-bg to start.`,
+          );
           continue;
         }
 
         const saved = formatBytes(stats.bytesSaved);
-        const pct = stats.bytesIn > 0
-          ? ` (${((stats.bytesSaved / stats.bytesIn) * 100).toFixed(1)}% reduction)`
-          : '';
+        const pct =
+          stats.bytesIn > 0
+            ? ` (${((stats.bytesSaved / stats.bytesIn) * 100).toFixed(1)}% reduction)`
+            : '';
         const lastRan = stats.lastRanAt
-          ? new Date(stats.lastRanAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+          ? new Date(stats.lastRanAt).toLocaleDateString('en-US', {
+              month: 'short',
+              day: 'numeric',
+              year: 'numeric',
+            })
           : '—';
 
         info(`\n  Site            ${site}`);
         info(`  Files touched   ${stats.filesTouched.toLocaleString()}`);
-        info(`  Operations      ${stats.succeeded.toLocaleString()} succeeded  /  ${(stats.totalOps - stats.succeeded).toLocaleString()} failed`);
+        info(
+          `  Operations      ${stats.succeeded.toLocaleString()} succeeded  /  ${(stats.totalOps - stats.succeeded).toLocaleString()} failed`,
+        );
         info(`  Bytes saved     ${saved}${pct}`);
         info(`  Last run        ${lastRan}`);
 

--- a/src/cli/components/InitWizard.tsx
+++ b/src/cli/components/InitWizard.tsx
@@ -11,8 +11,8 @@
  *   7. Save confirmation
  */
 
-import { useState, useEffect } from 'react';
 import { Box, Text, useApp, useInput } from 'ink';
+import { useEffect, useState } from 'react';
 import { AdapterResolver } from '../../adapters/resolver.ts';
 import type { SiteConfig } from '../../types.ts';
 import { loadConfig, saveConfig } from '../utils/config.ts';
@@ -53,7 +53,8 @@ export function InitWizard({
   const [authenticatedAs, setAuthenticatedAs] = useState('');
   const [capabilities, setCapabilities] = useState<Array<{ name: string; available: boolean }>>([]);
 
-  // Skip steps that already have values.
+  // Skip steps that already have values. Runs once on mount — deps intentionally empty.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only effect
   useEffect(() => {
     if (step === 'url' && initialUrl) {
       setUrl(normalizeUrl(initialUrl));
@@ -74,6 +75,7 @@ export function InitWizard({
   }, []);
 
   // Run connection test when we reach the testing step.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: stable refs; re-running on each dep change would break the wizard flow
   useEffect(() => {
     if (step !== 'testing') return;
 
@@ -89,9 +91,7 @@ export function InitWizard({
 
         if (!response.ok) {
           if (response.status === 401) {
-            setErrorMessage(
-              'Authentication failed. Check your username and Application Password.',
-            );
+            setErrorMessage('Authentication failed. Check your username and Application Password.');
           } else {
             setErrorMessage(`Connection failed: ${response.status} ${response.statusText}`);
           }
@@ -131,9 +131,7 @@ export function InitWizard({
         setSiteName(siteConfig.name);
         setStep('report');
       } catch (err) {
-        setErrorMessage(
-          `Could not connect: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        setErrorMessage(`Could not connect: ${err instanceof Error ? err.message : String(err)}`);
         setStep('error');
       }
     };
@@ -268,9 +266,7 @@ export function InitWizard({
       {/* Step 4: Password */}
       {step === 'password' ? (
         <Box flexDirection="column">
-          <Text dimColor>
-            Application Passwords: {url}/wp-admin/profile.php
-          </Text>
+          <Text dimColor>Application Passwords: {url}/wp-admin/profile.php</Text>
           <Box>
             <Text>Application Password: </Text>
             <Text color="green">{'*'.repeat(inputValue.length)}</Text>
@@ -309,18 +305,14 @@ export function InitWizard({
           <Text bold>Capabilities:</Text>
           {capabilities.map((cap) => (
             <Box key={cap.name}>
-              <Text>  </Text>
-              <Text color={cap.available ? 'green' : 'red'}>
-                {cap.available ? '✓' : '✗'}
-              </Text>
+              <Text> </Text>
+              <Text color={cap.available ? 'green' : 'red'}>{cap.available ? '✓' : '✗'}</Text>
               <Text> {cap.name}</Text>
             </Box>
           ))}
           <Text> </Text>
           {capabilities.some((c) => !c.available) ? (
-            <Text dimColor>
-              Tip: Configure SSH for WP-CLI to unlock all capabilities.
-            </Text>
+            <Text dimColor>Tip: Configure SSH for WP-CLI to unlock all capabilities.</Text>
           ) : null}
           <Text> </Text>
           <Text color="green" bold>

--- a/src/cli/components/MediaBrowser.tsx
+++ b/src/cli/components/MediaBrowser.tsx
@@ -8,8 +8,8 @@
  *   └ footer: keybindings ─────────────────────────────────────┘
  */
 
-import { useState, useEffect, useCallback } from 'react';
-import { Box, Text, useInput, useApp } from 'ink';
+import { Box, Text, useApp, useInput } from 'ink';
+import { useCallback, useEffect, useState } from 'react';
 import type { MediaItem, PagedResult, SortField, SortOrder } from '../../adapters/types.ts';
 
 export type MediaBrowserAction =
@@ -97,7 +97,9 @@ export function MediaBrowser({
     return () => clearInterval(id);
   }, [loading]);
 
-  // Auto-load thumbnail when selection changes.
+  // Auto-load thumbnail when selection changes. Keyed on item ID so the fetch
+  // only reruns when a different item is selected, not on every render.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally keyed on item id, not the full items array
   useEffect(() => {
     if (!canImages || !items[cursor]?.mimeType.startsWith('image/')) {
       setImageB64(null);
@@ -161,30 +163,45 @@ export function MediaBrowser({
     else if (input === 'n' || key.rightArrow) loadPage(page + 1);
     else if (input === 'b' || key.leftArrow) loadPage(page - 1);
     else if (input === 'q' || key.escape) doExit({ type: 'quit' });
-    else if (key.return) { const item = items[cursor]; if (item) doExit({ type: 'show', id: item.id }); }
-    else if (input === 'o') { const item = items[cursor]; if (item) doExit({ type: 'optimize', id: item.id }); }
-    else if (input === 'e') { const item = items[cursor]; if (item) doExit({ type: 'edit', id: item.id }); }
+    else if (key.return) {
+      const item = items[cursor];
+      if (item) doExit({ type: 'show', id: item.id });
+    } else if (input === 'o') {
+      const item = items[cursor];
+      if (item) doExit({ type: 'optimize', id: item.id });
+    } else if (input === 'e') {
+      const item = items[cursor];
+      if (item) doExit({ type: 'edit', id: item.id });
+    }
   });
 
   const selectedItem = items[cursor];
-  const scrollStart = Math.max(0, Math.min(cursor - Math.floor(listHeight / 2), items.length - listHeight));
+  const scrollStart = Math.max(
+    0,
+    Math.min(cursor - Math.floor(listHeight / 2), items.length - listHeight),
+  );
   const visibleItems = items.slice(scrollStart, scrollStart + listHeight);
   const hasPrev = page > 1;
   const hasNext = page < totalPages;
 
   return (
     <Box flexDirection="column" width={termWidth}>
-
       {/* ── Header ── */}
       <Box paddingX={1} justifyContent="space-between">
         <Box gap={1}>
-          <Text bold color="green">localPress</Text>
+          <Text bold color="green">
+            localPress
+          </Text>
           <Text dimColor>— media library</Text>
           {sortBy && sortBy !== 'date' && (
-            <Text dimColor>· {sortBy} {sortOrder ?? 'desc'}</Text>
+            <Text dimColor>
+              · {sortBy} {sortOrder ?? 'desc'}
+            </Text>
           )}
         </Box>
-        <Text dimColor>Page {page}/{totalPages} · {total} total</Text>
+        <Text dimColor>
+          Page {page}/{totalPages} · {total} total
+        </Text>
       </Box>
 
       {/* ── Page navigation bar ── */}
@@ -193,7 +210,9 @@ export function MediaBrowser({
           {hasPrev ? '← [b] prev page' : '              '}
         </Text>
         {loading && (
-          <Text color="green">{SPIN_FRAMES[spinFrame]} loading page {page}…</Text>
+          <Text color="green">
+            {SPIN_FRAMES[spinFrame]} loading page {page}…
+          </Text>
         )}
         <Text color={hasNext ? 'green' : undefined} dimColor={!hasNext}>
           {hasNext ? '[n] next page →' : '              '}
@@ -206,18 +225,14 @@ export function MediaBrowser({
 
       {/* ── Main ── */}
       <Box flexDirection="row">
-
         {/* List panel */}
         <Box flexDirection="column" width={listWidth}>
           {loading ? (
             // Full-panel spinner while page is in flight.
-            <Box
-              height={listHeight}
-              alignItems="center"
-              justifyContent="center"
-            >
+            <Box height={listHeight} alignItems="center" justifyContent="center">
               <Text color="green">
-                {SPIN_FRAMES[spinFrame]}{'  '}Loading page {page}…
+                {SPIN_FRAMES[spinFrame]}
+                {'  '}Loading page {page}…
               </Text>
             </Box>
           ) : loadError ? (
@@ -250,12 +265,8 @@ export function MediaBrowser({
                     {isSelected ? '▶ ' : '  '}
                     <Text color={isSelected ? undefined : 'cyan'}>
                       #{String(item.id).padEnd(5)}
-                    </Text>
-                    {' '}
-                    {name}
-                    {' '}
-                    <Text dimColor={!isSelected}>{ext}</Text>
-                    {' '}
+                    </Text>{' '}
+                    {name} <Text dimColor={!isSelected}>{ext}</Text>{' '}
                     <Text dimColor={!isSelected}>{size.padStart(8)}</Text>
                   </Text>
                 </Box>
@@ -287,9 +298,7 @@ export function MediaBrowser({
                     ) : (
                       <Box height={IMAGE_ROWS} alignItems="center" justifyContent="center">
                         <Text dimColor>
-                          {imageLoading
-                            ? `${SPIN_FRAMES[spinFrame]} loading preview…`
-                            : ''}
+                          {imageLoading ? `${SPIN_FRAMES[spinFrame]} loading preview…` : ''}
                         </Text>
                       </Box>
                     )}
@@ -297,25 +306,38 @@ export function MediaBrowser({
                 )}
 
                 {/* ── Metadata ── */}
-                <Text bold color="green" wrap="truncate">{selectedItem.filename}</Text>
+                <Text bold color="green" wrap="truncate">
+                  {selectedItem.filename}
+                </Text>
                 <Text dimColor>#{selectedItem.id}</Text>
                 <Text dimColor>{selectedItem.mimeType}</Text>
                 {selectedItem.sizeBytes !== undefined && (
                   <Text dimColor>{formatBytes(selectedItem.sizeBytes)}</Text>
                 )}
                 {selectedItem.width !== undefined && (
-                  <Text dimColor>{selectedItem.width}×{selectedItem.height}px</Text>
+                  <Text dimColor>
+                    {selectedItem.width}×{selectedItem.height}px
+                  </Text>
                 )}
-                {processedIds.has(selectedItem.id) && (
-                  <Text color="green">✓ optimized</Text>
-                )}
+                {processedIds.has(selectedItem.id) && <Text color="green">✓ optimized</Text>}
                 <Text> </Text>
-                <Text dimColor wrap="truncate">{selectedItem.url}</Text>
+                <Text dimColor wrap="truncate">
+                  {selectedItem.url}
+                </Text>
                 <Text> </Text>
                 <Text dimColor>──────────────────────</Text>
-                <Text><Text color="green">[o]</Text><Text dimColor> optimize</Text></Text>
-                <Text><Text color="green">[e]</Text><Text dimColor> edit (round-trip)</Text></Text>
-                <Text><Text color="green">[↵]</Text><Text dimColor> show details</Text></Text>
+                <Text>
+                  <Text color="green">[o]</Text>
+                  <Text dimColor> optimize</Text>
+                </Text>
+                <Text>
+                  <Text color="green">[e]</Text>
+                  <Text dimColor> edit (round-trip)</Text>
+                </Text>
+                <Text>
+                  <Text color="green">[↵]</Text>
+                  <Text dimColor> show details</Text>
+                </Text>
               </>
             ) : (
               <Text dimColor>No selection</Text>
@@ -330,10 +352,9 @@ export function MediaBrowser({
       </Box>
       <Box paddingX={1}>
         <Text dimColor>
-          [↑↓/jk] navigate  [←→/n/b] page  [o] optimize  [e] edit  [↵] details  [q] quit
+          [↑↓/jk] navigate [←→/n/b] page [o] optimize [e] edit [↵] details [q] quit
         </Text>
       </Box>
-
     </Box>
   );
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,6 +10,7 @@ import { Command, Option } from 'commander';
 
 import packageJson from '../../package.json' with { type: 'json' };
 import { registerAuditCommand } from './commands/audit.ts';
+import { registerCaptionCommand } from './commands/caption.ts';
 import { registerConfigCommand } from './commands/config.ts';
 import { registerConvertCommand } from './commands/convert.ts';
 import { registerDoctorCommand } from './commands/doctor.ts';
@@ -64,6 +65,7 @@ registerConfigCommand(program);
 registerListCommand(program);
 registerShowCommand(program);
 registerStatsCommand(program);
+registerCaptionCommand(program);
 registerAuditCommand(program);
 registerOptimizeCommand(program);
 registerConvertCommand(program);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,8 +24,8 @@ import { registerReferencesCommand } from './commands/references.ts';
 import { registerRemoveBgCommand } from './commands/remove-bg.ts';
 import { registerResizeCommand } from './commands/resize.ts';
 import { registerShowCommand } from './commands/show.ts';
-import { registerStatsCommand } from './commands/stats.ts';
 import { registerSitesCommand } from './commands/sites.ts';
+import { registerStatsCommand } from './commands/stats.ts';
 import { setOutputOptions } from './utils/output.ts';
 
 const program = new Command();

--- a/src/cli/utils/config.ts
+++ b/src/cli/utils/config.ts
@@ -71,8 +71,7 @@ export async function loadConfig(): Promise<Config> {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new Error(
-      `Failed to read config at ${configPath}: ${message}\n` +
-        'If the file is corrupt, you can delete it and run `localpress init` again.',
+      `Failed to read config at ${configPath}: ${message}\nIf the file is corrupt, you can delete it and run \`localpress init\` again.`,
     );
   }
 }
@@ -86,7 +85,7 @@ export async function saveConfig(config: Config): Promise<void> {
   mkdirSync(getSitesDir(), { recursive: true });
 
   // Write JSON with 2-space indent.
-  await Bun.write(configPath, JSON.stringify(config, null, 2) + '\n');
+  await Bun.write(configPath, `${JSON.stringify(config, null, 2)}\n`);
 
   // Restrict permissions on POSIX (Application Passwords are sensitive).
   if (process.platform !== 'win32') {

--- a/src/cli/utils/output.ts
+++ b/src/cli/utils/output.ts
@@ -65,5 +65,3 @@ export function printJson<T>(record: T): void {
     process.stdout.write(`${JSON.stringify(record, null, 2)}\n`);
   }
 }
-
-

--- a/src/engine/caption/ollama.ts
+++ b/src/engine/caption/ollama.ts
@@ -1,0 +1,82 @@
+/**
+ * Ollama vision provider for the caption command.
+ *
+ * Sends images to a locally-running Ollama instance and returns
+ * generated alt-text. Requires a multimodal model such as:
+ *   moondream  (~1.7GB, fast, great for alt-text)
+ *   llava      (~4GB+, higher quality)
+ *   bakllava   (~4GB+, alternative LLaVA variant)
+ */
+
+import type { CaptionOptions, CaptionResult } from './types.ts';
+
+export const DEFAULT_OLLAMA_MODEL = 'moondream';
+export const DEFAULT_OLLAMA_URL = 'http://localhost:11434';
+
+const DEFAULT_PROMPT =
+  'Write concise alt-text for this image. Describe only what is visually present. ' +
+  'Be factual and specific. Keep it under 125 characters. ' +
+  'Respond with only the alt-text — no prefix, quotes, or explanation.';
+
+interface OllamaGenerateResponse {
+  model: string;
+  response: string;
+  done: boolean;
+  error?: string;
+}
+
+interface OllamaTagsResponse {
+  models: Array<{ name: string; size: number; modified_at: string }>;
+}
+
+export async function isOllamaAvailable(baseUrl = DEFAULT_OLLAMA_URL): Promise<boolean> {
+  try {
+    const res = await fetch(`${baseUrl}/api/tags`, { signal: AbortSignal.timeout(3000) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function listOllamaModels(
+  baseUrl = DEFAULT_OLLAMA_URL,
+): Promise<Array<{ name: string; size: number }>> {
+  const res = await fetch(`${baseUrl}/api/tags`);
+  if (!res.ok) throw new Error(`Ollama /api/tags returned ${res.status}`);
+  const data = (await res.json()) as OllamaTagsResponse;
+  return data.models.map((m) => ({ name: m.name, size: m.size }));
+}
+
+export async function generateCaption(
+  imageBuffer: Buffer,
+  options: CaptionOptions = {},
+): Promise<CaptionResult> {
+  const baseUrl = options.ollamaUrl ?? DEFAULT_OLLAMA_URL;
+  const model = options.model ?? DEFAULT_OLLAMA_MODEL;
+  const prompt = options.prompt ?? DEFAULT_PROMPT;
+
+  const start = Date.now();
+  const b64 = imageBuffer.toString('base64');
+
+  const res = await fetch(`${baseUrl}/api/generate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model, prompt, images: [b64], stream: false }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Ollama returned ${res.status}: ${text}`);
+  }
+
+  const data = (await res.json()) as OllamaGenerateResponse;
+
+  if (data.error) throw new Error(`Ollama error: ${data.error}`);
+  if (!data.response) throw new Error('Ollama returned an empty response');
+
+  return {
+    caption: data.response.trim(),
+    model,
+    durationMs: Date.now() - start,
+  };
+}

--- a/src/engine/caption/types.ts
+++ b/src/engine/caption/types.ts
@@ -1,0 +1,11 @@
+export interface CaptionResult {
+  caption: string;
+  model: string;
+  durationMs: number;
+}
+
+export interface CaptionOptions {
+  model?: string;
+  prompt?: string;
+  ollamaUrl?: string;
+}

--- a/src/engine/image/jsquash.ts
+++ b/src/engine/image/jsquash.ts
@@ -71,8 +71,7 @@ export async function jsquashEncode(
 
     default:
       throw new Error(
-        `jSquash encoder does not support format '${format}'. ` +
-          'Supported: jpeg, png, webp, avif. Use --encoder sharp for other formats.',
+        `jSquash encoder does not support format '${format}'. Supported: jpeg, png, webp, avif. Use --encoder sharp for other formats.`,
       );
   }
 }

--- a/src/engine/image/optimize.ts
+++ b/src/engine/image/optimize.ts
@@ -14,14 +14,14 @@
  * reports stats. It doesn't know about WordPress or the CLI.
  */
 
-import type {
-    CompressionMode,
-    ImageFormat,
-    ImageInfo,
-    OptimizeOptions,
-    OptimizeResult,
-} from './types.ts';
 import { isJsquashSupported, jsquashEncode } from './jsquash.ts';
+import type {
+  CompressionMode,
+  ImageFormat,
+  ImageInfo,
+  OptimizeOptions,
+  OptimizeResult,
+} from './types.ts';
 
 /**
  * Optimize an image buffer according to the given options.

--- a/src/engine/rembg/remove-bg.ts
+++ b/src/engine/rembg/remove-bg.ts
@@ -130,8 +130,8 @@ export async function removeBackground(
   const outputData = outputTensor.data as Float32Array;
 
   // Normalize the mask to [0, 255].
-  let minVal = Infinity;
-  let maxVal = -Infinity;
+  let minVal = Number.POSITIVE_INFINITY;
+  let maxVal = Number.NEGATIVE_INFINITY;
   for (let i = 0; i < outputData.length; i++) {
     if (outputData[i] < minVal) minVal = outputData[i];
     if (outputData[i] > maxVal) maxVal = outputData[i];
@@ -156,7 +156,7 @@ export async function removeBackground(
     .toBuffer();
 
   // 8. Composite: apply mask as alpha channel to the original image.
-  let outputPipeline = sharp(imageBytes).ensureAlpha();
+  const outputPipeline = sharp(imageBytes).ensureAlpha();
 
   // Extract raw RGBA pixels.
   const rgbaBuffer = await outputPipeline.raw().toBuffer();

--- a/src/engine/state/db.ts
+++ b/src/engine/state/db.ts
@@ -212,8 +212,9 @@ export class SiteDb {
   // Stats ---------------------------------------------------------------------
 
   getStats(siteName: string): SiteStats {
-    const ops = this.db.query(
-      `SELECT operation,
+    const ops = this.db
+      .query(
+        `SELECT operation,
               COUNT(*)                                          AS total,
               SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) AS succeeded,
               SUM(CASE WHEN status = 'failure' THEN 1 ELSE 0 END) AS failed,
@@ -226,10 +227,12 @@ export class SiteDb {
        WHERE site_name = ?
        GROUP BY operation
        ORDER BY total DESC`,
-    ).all(siteName) as RawOpStat[];
+      )
+      .all(siteName) as RawOpStat[];
 
-    const totals = this.db.query(
-      `SELECT COUNT(DISTINCT wp_id)                                       AS files_touched,
+    const totals = this.db
+      .query(
+        `SELECT COUNT(DISTINCT wp_id)                                       AS files_touched,
               SUM(CASE WHEN bytes_before > bytes_after THEN bytes_before - bytes_after ELSE 0 END) AS bytes_saved,
               SUM(bytes_before)                                           AS bytes_in,
               COUNT(*)                                                    AS total_ops,
@@ -237,7 +240,8 @@ export class SiteDb {
               MAX(ran_at)                                                 AS last_ran_at
        FROM processing_history
        WHERE site_name = ?`,
-    ).get(siteName) as RawTotalStat | null;
+      )
+      .get(siteName) as RawTotalStat | null;
 
     return {
       siteName,

--- a/test/integration/wp-rest.test.ts
+++ b/test/integration/wp-rest.test.ts
@@ -18,6 +18,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 
 import { AdapterResolver } from '../../src/adapters/resolver.ts';
 import { RestAdapter } from '../../src/adapters/rest.ts';
+import { CapabilityUnavailableError } from '../../src/adapters/types.ts';
 import { SiteDb } from '../../src/engine/state/db.ts';
 import type { SiteConfig } from '../../src/types.ts';
 
@@ -119,7 +120,7 @@ describe.skipIf(!canRun)('WordPress REST API integration', () => {
     const item = items[0];
 
     await expect(adapter.replaceInPlace(item.id, Buffer.from(''))).rejects.toThrow(
-      'CapabilityUnavailableError',
+      CapabilityUnavailableError,
     );
   });
 

--- a/test/integration/wp-rest.test.ts
+++ b/test/integration/wp-rest.test.ts
@@ -16,10 +16,10 @@
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 
-import { RestAdapter } from '../../src/adapters/rest.ts';
 import { AdapterResolver } from '../../src/adapters/resolver.ts';
-import type { SiteConfig } from '../../src/types.ts';
+import { RestAdapter } from '../../src/adapters/rest.ts';
 import { SiteDb } from '../../src/engine/state/db.ts';
+import type { SiteConfig } from '../../src/types.ts';
 
 const WP_URL = process.env.WP_TEST_URL;
 const WP_USER = process.env.WP_TEST_USER;
@@ -191,7 +191,7 @@ describe.skipIf(!canRun)('WordPress REST API integration', () => {
     // Verify getLastProcessing returns the record.
     const last = db.getLastProcessing(testSite.name, item.id);
     expect(last).not.toBeNull();
-    expect(last!.sourceHash).toBe('test-hash-123');
-    expect(last!.bytesAfter).toBe(20000);
+    expect(last?.sourceHash).toBe('test-hash-123');
+    expect(last?.bytesAfter).toBe(20000);
   });
 });

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -3,10 +3,10 @@
  * Uses a temp directory to avoid touching the real config.
  */
 
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 
 import type { Config } from '../../src/types.ts';
 
@@ -23,7 +23,7 @@ beforeEach(() => {
 
 afterEach(() => {
   if (originalXdg === undefined) {
-    delete process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = undefined;
   } else {
     process.env.XDG_CONFIG_HOME = originalXdg;
   }

--- a/test/unit/db.test.ts
+++ b/test/unit/db.test.ts
@@ -90,15 +90,15 @@ describe('attachment CRUD', () => {
 
     const att = db.getAttachment('test-site', 42);
     expect(att).not.toBeNull();
-    expect(att!.siteName).toBe('test-site');
-    expect(att!.wpId).toBe(42);
-    expect(att!.sourceUrl).toBe('https://example.test/wp-content/uploads/photo.jpg');
-    expect(att!.sourceHash).toBe('abc123');
-    expect(att!.sizeBytes).toBe(2048);
-    expect(att!.width).toBe(1920);
-    expect(att!.height).toBe(1080);
-    expect(att!.mimeType).toBe('image/jpeg');
-    expect(att!.lastSeenAt).toBe(now);
+    expect(att?.siteName).toBe('test-site');
+    expect(att?.wpId).toBe(42);
+    expect(att?.sourceUrl).toBe('https://example.test/wp-content/uploads/photo.jpg');
+    expect(att?.sourceHash).toBe('abc123');
+    expect(att?.sizeBytes).toBe(2048);
+    expect(att?.width).toBe(1920);
+    expect(att?.height).toBe(1080);
+    expect(att?.mimeType).toBe('image/jpeg');
+    expect(att?.lastSeenAt).toBe(now);
 
     db.close();
   });
@@ -137,10 +137,10 @@ describe('attachment CRUD', () => {
     });
 
     const att = db.getAttachment('test-site', 1);
-    expect(att!.sourceUrl).toBe('https://example.test/new.jpg');
-    expect(att!.sourceHash).toBe('hash2');
-    expect(att!.sizeBytes).toBe(2000);
-    expect(att!.lastSeenAt).toBe(2000);
+    expect(att?.sourceUrl).toBe('https://example.test/new.jpg');
+    expect(att?.sourceHash).toBe('hash2');
+    expect(att?.sizeBytes).toBe(2000);
+    expect(att?.lastSeenAt).toBe(2000);
 
     db.close();
   });
@@ -192,11 +192,11 @@ describe('attachment CRUD', () => {
     });
 
     const att = db.getAttachment('test-site', 1);
-    expect(att!.sourceHash).toBeNull();
-    expect(att!.sizeBytes).toBeNull();
-    expect(att!.width).toBeNull();
-    expect(att!.height).toBeNull();
-    expect(att!.mimeType).toBeNull();
+    expect(att?.sourceHash).toBeNull();
+    expect(att?.sizeBytes).toBeNull();
+    expect(att?.width).toBeNull();
+    expect(att?.height).toBeNull();
+    expect(att?.mimeType).toBeNull();
 
     db.close();
   });
@@ -239,12 +239,12 @@ describe('processing history', () => {
 
     const record = db.getLastProcessing('test-site', 10);
     expect(record).not.toBeNull();
-    expect(record!.id).toBe(id);
-    expect(record!.operation).toBe('optimize');
-    expect(record!.bytesBefore).toBe(5000);
-    expect(record!.bytesAfter).toBe(1200);
-    expect(record!.status).toBe('success');
-    expect(record!.durationMs).toBe(350);
+    expect(record?.id).toBe(id);
+    expect(record?.operation).toBe('optimize');
+    expect(record?.bytesBefore).toBe(5000);
+    expect(record?.bytesAfter).toBe(1200);
+    expect(record?.status).toBe('success');
+    expect(record?.durationMs).toBe(350);
 
     db.close();
   });
@@ -298,8 +298,8 @@ describe('processing history', () => {
     });
 
     const record = db.getLastProcessing('test-site', 20);
-    expect(record!.ranAt).toBe(now);
-    expect(record!.bytesAfter).toBe(1500);
+    expect(record?.ranAt).toBe(now);
+    expect(record?.bytesAfter).toBe(1500);
 
     db.close();
   });
@@ -353,12 +353,12 @@ describe('processing history', () => {
     });
 
     const optimizeRecord = db.getLastProcessing('test-site', 30, 'optimize');
-    expect(optimizeRecord!.operation).toBe('optimize');
-    expect(optimizeRecord!.bytesAfter).toBe(2000);
+    expect(optimizeRecord?.operation).toBe('optimize');
+    expect(optimizeRecord?.bytesAfter).toBe(2000);
 
     const convertRecord = db.getLastProcessing('test-site', 30, 'convert');
-    expect(convertRecord!.operation).toBe('convert');
-    expect(convertRecord!.bytesAfter).toBe(1000);
+    expect(convertRecord?.operation).toBe('convert');
+    expect(convertRecord?.bytesAfter).toBe(1000);
 
     db.close();
   });
@@ -402,8 +402,8 @@ describe('processing history', () => {
     });
 
     const record = db.getLastProcessing('test-site', 40);
-    expect(record!.status).toBe('failure');
-    expect(record!.errorMessage).toBe('Codec error: unsupported format');
+    expect(record?.status).toBe('failure');
+    expect(record?.errorMessage).toBe('Codec error: unsupported format');
 
     db.close();
   });


### PR DESCRIPTION
## Summary

- New `localpress caption` command — generates alt-text using a locally-running Ollama vision model
- Zero cloud dependency, zero API keys, fits the "your laptop, your library" positioning
- Recommended model: `moondream` (~1.7 GB, fast and accurate); `llava`, `bakllava` also supported
- Engine layer in `src/engine/caption/` — clean separation between Ollama HTTP client and CLI

## Key flags

| Flag | Behaviour |
|---|---|
| `localpress caption 123 124` | Caption specific attachments by ID |
| `--missing-alt` | Auto-fetch and caption all images with no alt text set |
| `--dry-run` | Print generated captions without touching WordPress |
| `--overwrite` | Replace existing alt text (default: skip) |
| `--model <name>` | Choose Ollama model (default: `moondream`) |
| `--list-models` | Show locally-available vision models |
| `--prompt <text>` | Custom system prompt |
| `--ollama-url <url>` | Override Ollama base URL (default: `http://localhost:11434`) |

## Implementation notes

- Checks Ollama is reachable before doing any work; exits with friendly instructions if not
- `--missing-alt` paginates the full media library to find items with no `altText`
- Skips non-image attachments with a warning
- Records every run (success and failure) in `processing_history` with `operation: 'caption'`
- `updateMetadata()` via `update-meta` capability writes alt text back to WordPress
- `--json` output includes `{ dryRun, processed, skipped, failures, results[] }`

## Test plan

- [ ] `localpress caption --list-models` when Ollama running — shows vision models
- [ ] `localpress caption --list-models` when Ollama not running — clean error with instructions
- [ ] `localpress caption 123 --dry-run` — prints caption, WordPress alt text unchanged
- [ ] `localpress caption 123` — caption generated and written to WP attachment
- [ ] `localpress caption 123` second run — skipped (alt text already set)
- [ ] `localpress caption 123 --overwrite` — replaces existing alt text
- [ ] `localpress caption --missing-alt` — finds and captions all missing-alt images
- [ ] `localpress stats` after captioning — shows `caption` operation in breakdown
- [ ] `bun run typecheck` passes
- [ ] `bun test test/unit/` — 36 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)