### PR TITLE
feat: SSH configuration in init wizard + explicit user field

### DIFF
--- a/src/adapters/ssh.ts
+++ b/src/adapters/ssh.ts
@@ -47,7 +47,7 @@ export async function scpUpload(
   args.push('-o', 'BatchMode=yes');
 
   args.push(localPath);
-  args.push(`${ssh.host}:${remotePath}`);
+  args.push(`${sshDestination(ssh)}:${remotePath}`);
 
   return execProcess('scp', args);
 }
@@ -72,15 +72,26 @@ export async function scpDownload(
   args.push('-o', 'StrictHostKeyChecking=accept-new');
   args.push('-o', 'BatchMode=yes');
 
-  args.push(`${ssh.host}:${remotePath}`);
+  args.push(`${sshDestination(ssh)}:${remotePath}`);
   args.push(localPath);
 
   return execProcess('scp', args);
 }
 
-// -- Internal helpers ---------------------------------------------------------
+// -- Internal helpers (exported for testing) ----------------------------------
 
-function buildSshArgs(ssh: SshConfig): string[] {
+/**
+ * Build the user@host destination string from config fields.
+ * Supports legacy configs where user@ is already embedded in host.
+ */
+export function sshDestination(ssh: SshConfig): string {
+  if (ssh.user && !ssh.host.includes('@')) {
+    return `${ssh.user}@${ssh.host}`;
+  }
+  return ssh.host;
+}
+
+export function buildSshArgs(ssh: SshConfig): string[] {
   const args: string[] = [];
 
   if (ssh.port && ssh.port !== 22) {
@@ -94,7 +105,7 @@ function buildSshArgs(ssh: SshConfig): string[] {
   args.push('-o', 'StrictHostKeyChecking=accept-new');
   args.push('-o', 'BatchMode=yes');
 
-  args.push(ssh.host);
+  args.push(sshDestination(ssh));
 
   return args;
 }

--- a/src/adapters/wp-cli.ts
+++ b/src/adapters/wp-cli.ts
@@ -486,7 +486,7 @@ interface WpCliAttachmentMeta {
 
 // Helper for callers that want to check availability.
 export function isWpCliAvailableForSite(site: SiteConfig): boolean {
-  return Boolean(site.ssh?.host && site.ssh?.wpPath);
+  return Boolean(site.ssh?.host && site.ssh?.user && site.ssh?.wpPath);
 }
 
 export { CapabilityUnavailableError } from './types.ts';

--- a/src/cli/components/InitWizard.tsx
+++ b/src/cli/components/InitWizard.tsx
@@ -8,13 +8,21 @@
  *   4. Application Password input (masked)
  *   5. Connection test (spinner)
  *   6. Capability report
- *   7. Save confirmation
+ *   7. SSH configuration prompt (optional)
+ *   8. SSH host input
+ *   9. SSH user input
+ *  10. SSH port input
+ *  11. SSH wpPath input
+ *  12. SSH identityFile input (optional)
+ *  13. SSH connection test
+ *  14. Final capability report
+ *  15. Save confirmation
  */
 
 import { Box, Text, useApp, useInput } from 'ink';
 import { useEffect, useState } from 'react';
 import { AdapterResolver } from '../../adapters/resolver.ts';
-import type { SiteConfig } from '../../types.ts';
+import type { SiteConfig, SshConfig } from '../../types.ts';
 import { loadConfig, saveConfig } from '../utils/config.ts';
 
 type WizardStep =
@@ -24,6 +32,15 @@ type WizardStep =
   | 'password'
   | 'testing'
   | 'report'
+  | 'ssh-prompt'
+  | 'ssh-host'
+  | 'ssh-user'
+  | 'ssh-port'
+  | 'ssh-wp-path'
+  | 'ssh-identity-file'
+  | 'ssh-testing'
+  | 'ssh-error'
+  | 'final-report'
   | 'done'
   | 'error';
 
@@ -52,6 +69,15 @@ export function InitWizard({
   const [errorMessage, setErrorMessage] = useState('');
   const [authenticatedAs, setAuthenticatedAs] = useState('');
   const [capabilities, setCapabilities] = useState<Array<{ name: string; available: boolean }>>([]);
+
+  // SSH state
+  const [sshHost, setSshHost] = useState('');
+  const [sshUser, setSshUser] = useState('');
+  const [sshPort, setSshPort] = useState('22');
+  const [sshWpPath, setSshWpPath] = useState('');
+  const [sshIdentityFile, setSshIdentityFile] = useState('');
+  const [sshErrorMessage, setSshErrorMessage] = useState('');
+  const [, setSshConfigured] = useState(false);
 
   // Skip steps that already have values. Runs once on mount — deps intentionally empty.
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only effect
@@ -102,7 +128,7 @@ export function InitWizard({
         const user = (await response.json()) as { name?: string; slug?: string };
         setAuthenticatedAs(user.name ?? user.slug ?? username);
 
-        // Build capability report.
+        // Build capability report (REST-only at this point).
         const siteConfig: SiteConfig = {
           name: siteName || new URL(normalizedUrl).hostname,
           url: normalizedUrl,
@@ -120,7 +146,7 @@ export function InitWizard({
           })),
         );
 
-        // Save config.
+        // Save config (without SSH for now).
         const config = await loadConfig();
         config.sites[siteConfig.name] = siteConfig;
         if (!config.activeSite) {
@@ -139,10 +165,122 @@ export function InitWizard({
     testConnection();
   }, [step]);
 
+  // Run SSH connection test.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: stable refs; re-running on each dep change would break the wizard flow
+  useEffect(() => {
+    if (step !== 'ssh-testing') return;
+
+    const testSsh = async () => {
+      try {
+        const { sshExec } = await import('../../adapters/ssh.ts');
+
+        const sshConfig: SshConfig = {
+          host: sshHost,
+          user: sshUser,
+          port: Number.parseInt(sshPort, 10) || 22,
+          wpPath: sshWpPath,
+        };
+        if (sshIdentityFile) {
+          sshConfig.identityFile = sshIdentityFile;
+        }
+
+        // Test 1: Can we SSH in and run wp --info?
+        const wpInfoResult = await sshExec(
+          sshConfig,
+          `cd ${sshWpPath} && wp --info --allow-root 2>/dev/null || echo "__WP_CLI_NOT_FOUND__"`,
+        );
+
+        if (wpInfoResult.exitCode !== 0) {
+          setSshErrorMessage(
+            `SSH connection failed (exit ${wpInfoResult.exitCode}): ${wpInfoResult.stderr || 'Could not connect'}`,
+          );
+          setStep('ssh-error');
+          return;
+        }
+
+        if (wpInfoResult.stdout.includes('__WP_CLI_NOT_FOUND__')) {
+          setSshErrorMessage(
+            'SSH connected, but WP-CLI is not installed or not in PATH on the remote server.\n' +
+              'Install WP-CLI: https://wp-cli.org/#installing',
+          );
+          setStep('ssh-error');
+          return;
+        }
+
+        // Test 2: Verify wpPath has wp-config.php
+        const wpConfigResult = await sshExec(
+          sshConfig,
+          `test -f "${sshWpPath}/wp-config.php" && echo "OK" || echo "MISSING"`,
+        );
+
+        if (wpConfigResult.stdout.trim() === 'MISSING') {
+          setSshErrorMessage(
+            `wp-config.php not found at ${sshWpPath}. Check that wpPath points to your WordPress root directory.`,
+          );
+          setStep('ssh-error');
+          return;
+        }
+
+        // SSH works! Save the config with SSH.
+        const config = await loadConfig();
+        const siteConfig = config.sites[siteName];
+        if (siteConfig) {
+          siteConfig.ssh = sshConfig;
+          await saveConfig(config);
+        }
+
+        setSshConfigured(true);
+
+        // Rebuild capability report with SSH.
+        const updatedSiteConfig: SiteConfig = {
+          ...siteConfig,
+          ssh: sshConfig,
+        } as SiteConfig;
+        const resolver = new AdapterResolver(updatedSiteConfig);
+        const report = resolver.capabilityReport();
+        setCapabilities(
+          report.map((r) => ({
+            name: r.capability,
+            available: r.preferredAdapter !== null,
+          })),
+        );
+
+        setStep('final-report');
+      } catch (err) {
+        setSshErrorMessage(`SSH test failed: ${err instanceof Error ? err.message : String(err)}`);
+        setStep('ssh-error');
+      }
+    };
+
+    testSsh();
+  }, [step]);
+
   // Handle text input.
   useInput((input, key) => {
-    if (step === 'report' || step === 'done') {
+    if (step === 'final-report' || step === 'done') {
       if (key.return || input === 'q') {
+        exit();
+      }
+      return;
+    }
+
+    // Report step: y/n for SSH prompt, or Enter to skip
+    if (step === 'report') {
+      if (input === 'y' || input === 'Y') {
+        setInputValue('');
+        setStep('ssh-host');
+        return;
+      }
+      if (input === 'n' || input === 'N' || key.return) {
+        exit();
+        return;
+      }
+      return;
+    }
+
+    if (step === 'ssh-error') {
+      if (key.return) {
+        // Allow retry or skip
         exit();
       }
       return;
@@ -153,7 +291,7 @@ export function InitWizard({
       return;
     }
 
-    if (step === 'testing') return;
+    if (step === 'testing' || step === 'ssh-testing') return;
 
     if (key.return) {
       submitCurrentStep();
@@ -210,8 +348,47 @@ export function InitWizard({
         setStep('testing');
         break;
       }
+      case 'ssh-host': {
+        const value = inputValue.trim() || getHostname(url);
+        setSshHost(value);
+        setInputValue('');
+        setStep('ssh-user');
+        break;
+      }
+      case 'ssh-user': {
+        const value = inputValue.trim();
+        if (!value) return;
+        setSshUser(value);
+        setInputValue('');
+        setStep('ssh-port');
+        break;
+      }
+      case 'ssh-port': {
+        const value = inputValue.trim() || '22';
+        setSshPort(value);
+        setInputValue('');
+        setStep('ssh-wp-path');
+        break;
+      }
+      case 'ssh-wp-path': {
+        const value = inputValue.trim();
+        if (!value) return;
+        setSshWpPath(value);
+        setInputValue('');
+        setStep('ssh-identity-file');
+        break;
+      }
+      case 'ssh-identity-file': {
+        const value = inputValue.trim();
+        setSshIdentityFile(value);
+        setInputValue('');
+        setStep('ssh-testing');
+        break;
+      }
     }
   }
+
+  const hasMissingCapabilities = capabilities.some((c) => !c.available);
 
   return (
     <Box flexDirection="column" paddingLeft={1} paddingTop={1}>
@@ -288,7 +465,7 @@ export function InitWizard({
         </Box>
       ) : null}
 
-      {/* Step 6: Report */}
+      {/* Step 6: Report + SSH prompt */}
       {step === 'report' ? (
         <Box flexDirection="column">
           <Text> </Text>
@@ -311,12 +488,223 @@ export function InitWizard({
             </Box>
           ))}
           <Text> </Text>
-          {capabilities.some((c) => !c.available) ? (
-            <Text dimColor>Tip: Configure SSH for WP-CLI to unlock all capabilities.</Text>
-          ) : null}
+          {hasMissingCapabilities ? (
+            <Box flexDirection="column">
+              <Text dimColor>
+                SSH + WP-CLI unlocks: replace-in-place, regenerate-thumbnails, prune-orphans,
+                full-references.
+              </Text>
+              <Text dimColor>Requires: SSH access to your server with WP-CLI installed.</Text>
+              <Text> </Text>
+              <Text>Configure SSH now? </Text>
+              <Text color="cyan">[y/N]</Text>
+            </Box>
+          ) : (
+            <Box flexDirection="column">
+              <Text color="green" bold>
+                All capabilities available!
+              </Text>
+              <Text dimColor>Press Enter to exit.</Text>
+            </Box>
+          )}
+        </Box>
+      ) : null}
+
+      {/* SSH Configuration Steps */}
+      {(step === 'ssh-host' ||
+        step === 'ssh-user' ||
+        step === 'ssh-port' ||
+        step === 'ssh-wp-path' ||
+        step === 'ssh-identity-file' ||
+        step === 'ssh-testing' ||
+        step === 'ssh-error' ||
+        step === 'final-report') && (
+        <Box flexDirection="column">
+          <Text> </Text>
+          <Box>
+            <Text color="green">✓</Text>
+            <Text> Authenticated as </Text>
+            <Text bold>{authenticatedAs}</Text>
+          </Box>
+          <Box>
+            <Text color="green">✓</Text>
+            <Text> Site '{siteName}' saved and set as active.</Text>
+          </Box>
+          <Text> </Text>
+          <Text bold color="cyan">
+            SSH Configuration (WP-CLI)
+          </Text>
+          <Text dimColor>─────────────────────────────────────</Text>
+          <Text> </Text>
+        </Box>
+      )}
+
+      {/* SSH Host */}
+      {step === 'ssh-host' ? (
+        <Box>
+          <Text>SSH host [{getHostname(url)}]: </Text>
+          <Text color="green">{inputValue}</Text>
+          <Text color="gray">▌</Text>
+        </Box>
+      ) : sshHost &&
+        (step === 'ssh-user' ||
+          step === 'ssh-port' ||
+          step === 'ssh-wp-path' ||
+          step === 'ssh-identity-file' ||
+          step === 'ssh-testing' ||
+          step === 'ssh-error' ||
+          step === 'final-report') ? (
+        <Box>
+          <Text color="green">✓</Text>
+          <Text> SSH host: {sshHost}</Text>
+        </Box>
+      ) : null}
+
+      {/* SSH User */}
+      {step === 'ssh-user' ? (
+        <Box>
+          <Text>SSH user: </Text>
+          <Text color="green">{inputValue}</Text>
+          <Text color="gray">▌</Text>
+        </Box>
+      ) : sshUser &&
+        (step === 'ssh-port' ||
+          step === 'ssh-wp-path' ||
+          step === 'ssh-identity-file' ||
+          step === 'ssh-testing' ||
+          step === 'ssh-error' ||
+          step === 'final-report') ? (
+        <Box>
+          <Text color="green">✓</Text>
+          <Text> SSH user: {sshUser}</Text>
+        </Box>
+      ) : null}
+
+      {/* SSH Port */}
+      {step === 'ssh-port' ? (
+        <Box>
+          <Text>SSH port [22]: </Text>
+          <Text color="green">{inputValue}</Text>
+          <Text color="gray">▌</Text>
+        </Box>
+      ) : sshPort &&
+        (step === 'ssh-wp-path' ||
+          step === 'ssh-identity-file' ||
+          step === 'ssh-testing' ||
+          step === 'ssh-error' ||
+          step === 'final-report') ? (
+        <Box>
+          <Text color="green">✓</Text>
+          <Text> SSH port: {sshPort}</Text>
+        </Box>
+      ) : null}
+
+      {/* SSH WordPress Path */}
+      {step === 'ssh-wp-path' ? (
+        <Box flexDirection="column">
+          <Text dimColor>
+            Absolute path to WordPress root on the server (where wp-config.php lives).
+          </Text>
+          <Box>
+            <Text>WordPress path: </Text>
+            <Text color="green">{inputValue}</Text>
+            <Text color="gray">▌</Text>
+          </Box>
+        </Box>
+      ) : sshWpPath &&
+        (step === 'ssh-identity-file' ||
+          step === 'ssh-testing' ||
+          step === 'ssh-error' ||
+          step === 'final-report') ? (
+        <Box>
+          <Text color="green">✓</Text>
+          <Text> WordPress path: {sshWpPath}</Text>
+        </Box>
+      ) : null}
+
+      {/* SSH Identity File */}
+      {step === 'ssh-identity-file' ? (
+        <Box flexDirection="column">
+          <Text dimColor>
+            Path to SSH private key (leave blank to use ssh-agent or ~/.ssh/id_rsa).
+          </Text>
+          <Box>
+            <Text>Identity file [ssh-agent]: </Text>
+            <Text color="green">{inputValue}</Text>
+            <Text color="gray">▌</Text>
+          </Box>
+        </Box>
+      ) : sshIdentityFile &&
+        (step === 'ssh-testing' || step === 'ssh-error' || step === 'final-report') ? (
+        <Box>
+          <Text color="green">✓</Text>
+          <Text> Identity file: {sshIdentityFile}</Text>
+        </Box>
+      ) : !sshIdentityFile &&
+        (step === 'ssh-testing' || step === 'ssh-error' || step === 'final-report') ? (
+        <Box>
+          <Text color="green">✓</Text>
+          <Text> Identity file: (ssh-agent)</Text>
+        </Box>
+      ) : null}
+
+      {/* SSH Testing */}
+      {step === 'ssh-testing' ? (
+        <Box>
+          <Text color="yellow">⠋</Text>
+          <Text>
+            {' '}
+            Testing SSH connection to {sshUser}@{sshHost}...
+          </Text>
+        </Box>
+      ) : null}
+
+      {/* SSH Error */}
+      {step === 'ssh-error' ? (
+        <Box flexDirection="column">
+          <Text> </Text>
+          <Box>
+            <Text color="red">✗</Text>
+            <Text> {sshErrorMessage}</Text>
+          </Box>
+          <Text> </Text>
+          <Text dimColor>
+            SSH setup skipped. You can configure it later by editing your config file:
+          </Text>
+          <Text dimColor> localpress config get</Text>
+          <Text dimColor>Or re-run: localpress init --site {siteName}</Text>
+          <Text> </Text>
+          <Text dimColor>Press Enter to exit.</Text>
+        </Box>
+      ) : null}
+
+      {/* Final Report (after SSH configured) */}
+      {step === 'final-report' ? (
+        <Box flexDirection="column">
+          <Text> </Text>
+          <Box>
+            <Text color="green">✓</Text>
+            <Text>
+              {' '}
+              SSH connected to {sshUser}@{sshHost}
+            </Text>
+          </Box>
+          <Box>
+            <Text color="green">✓</Text>
+            <Text> WP-CLI verified at {sshWpPath}</Text>
+          </Box>
+          <Text> </Text>
+          <Text bold>Capabilities (with WP-CLI):</Text>
+          {capabilities.map((cap) => (
+            <Box key={cap.name}>
+              <Text> </Text>
+              <Text color={cap.available ? 'green' : 'red'}>{cap.available ? '✓' : '✗'}</Text>
+              <Text> {cap.name}</Text>
+            </Box>
+          ))}
           <Text> </Text>
           <Text color="green" bold>
-            Ready! Try `localpress list` to see your media library.
+            Ready! All capabilities unlocked. Try `localpress list` to see your media library.
           </Text>
           <Text dimColor>Press Enter to exit.</Text>
         </Box>

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,13 +26,15 @@ export interface SiteConfig {
 }
 
 export interface SshConfig {
-  /** SSH host (may include user@). */
+  /** SSH hostname or IP address. */
   host: string;
+  /** SSH username on the remote server. */
+  user: string;
   /** Optional SSH port (default 22). */
   port?: number;
-  /** Path to the WordPress install on the remote host. */
+  /** Absolute path to the WordPress installation directory on the remote host. */
   wpPath: string;
-  /** Optional path to the SSH key (default: use ssh-agent / ~/.ssh/id_rsa). */
+  /** Optional path to the SSH private key (default: use ssh-agent / ~/.ssh/id_rsa). */
   identityFile?: string;
 }
 

--- a/test/unit/smoke.test.ts
+++ b/test/unit/smoke.test.ts
@@ -26,7 +26,8 @@ const fakeWpCliSite: SiteConfig = {
   ...fakeRestOnlySite,
   name: 'test-wp-cli',
   ssh: {
-    host: 'admin@example.test',
+    host: 'example.test',
+    user: 'admin',
     wpPath: '/var/www/wordpress',
   },
 };

--- a/test/unit/ssh.test.ts
+++ b/test/unit/ssh.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Unit tests for SSH adapter helpers and WP-CLI availability detection.
+ *
+ * These tests verify:
+ * - sshDestination() builds correct user@host strings
+ * - buildSshArgs() produces correct SSH command arguments
+ * - isWpCliAvailableForSite() correctly gates on required fields
+ * - AdapterResolver behavior with various SSH config shapes
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { AdapterResolver } from '../../src/adapters/resolver.ts';
+import { buildSshArgs, sshDestination } from '../../src/adapters/ssh.ts';
+import { isWpCliAvailableForSite } from '../../src/adapters/wp-cli.ts';
+import type { SiteConfig, SshConfig } from '../../src/types.ts';
+
+// -- Test fixtures ------------------------------------------------------------
+
+const baseSite: SiteConfig = {
+  name: 'test-site',
+  url: 'https://example.test',
+  username: 'admin',
+  appPassword: 'aaaa bbbb cccc dddd eeee ffff',
+  createdAt: new Date('2026-01-01').toISOString(),
+};
+
+const minimalSsh: SshConfig = {
+  host: 'example.test',
+  user: 'deploy',
+  wpPath: '/var/www/html',
+};
+
+const fullSsh: SshConfig = {
+  host: '203.0.113.42',
+  user: 'ubuntu',
+  port: 2222,
+  wpPath: '/var/www/wordpress',
+  identityFile: '~/.ssh/id_ed25519',
+};
+
+const legacySsh: SshConfig = {
+  host: 'deploy@example.test',
+  user: '',
+  wpPath: '/var/www/html',
+};
+
+// -- sshDestination -----------------------------------------------------------
+
+describe('sshDestination', () => {
+  test('builds user@host from separate fields', () => {
+    expect(sshDestination(minimalSsh)).toBe('deploy@example.test');
+  });
+
+  test('builds user@host with IP address', () => {
+    expect(sshDestination(fullSsh)).toBe('ubuntu@203.0.113.42');
+  });
+
+  test('preserves legacy user@host format when user is empty', () => {
+    expect(sshDestination(legacySsh)).toBe('deploy@example.test');
+  });
+
+  test('does not double-prefix when host already contains @', () => {
+    const ssh: SshConfig = {
+      host: 'admin@example.test',
+      user: 'admin',
+      wpPath: '/var/www/html',
+    };
+    // When host already has @, use it as-is (legacy compat)
+    expect(sshDestination(ssh)).toBe('admin@example.test');
+  });
+
+  test('handles subdomain hosts', () => {
+    const ssh: SshConfig = {
+      host: 'ssh.mysite.kinsta.cloud',
+      user: 'mysite',
+      wpPath: '/www/mysite/public',
+    };
+    expect(sshDestination(ssh)).toBe('mysite@ssh.mysite.kinsta.cloud');
+  });
+});
+
+// -- buildSshArgs -------------------------------------------------------------
+
+describe('buildSshArgs', () => {
+  test('minimal config produces correct args', () => {
+    const args = buildSshArgs(minimalSsh);
+    expect(args).toContain('-o');
+    expect(args).toContain('StrictHostKeyChecking=accept-new');
+    expect(args).toContain('BatchMode=yes');
+    expect(args[args.length - 1]).toBe('deploy@example.test');
+    // No -p flag for default port
+    expect(args).not.toContain('-p');
+    // No -i flag without identityFile
+    expect(args).not.toContain('-i');
+  });
+
+  test('custom port adds -p flag', () => {
+    const args = buildSshArgs(fullSsh);
+    const portIdx = args.indexOf('-p');
+    expect(portIdx).toBeGreaterThanOrEqual(0);
+    expect(args[portIdx + 1]).toBe('2222');
+  });
+
+  test('port 22 does not add -p flag', () => {
+    const ssh: SshConfig = { ...minimalSsh, port: 22 };
+    const args = buildSshArgs(ssh);
+    expect(args).not.toContain('-p');
+  });
+
+  test('identityFile adds -i flag', () => {
+    const args = buildSshArgs(fullSsh);
+    const iIdx = args.indexOf('-i');
+    expect(iIdx).toBeGreaterThanOrEqual(0);
+    expect(args[iIdx + 1]).toBe('~/.ssh/id_ed25519');
+  });
+
+  test('destination is always the last argument', () => {
+    const args = buildSshArgs(fullSsh);
+    expect(args[args.length - 1]).toBe('ubuntu@203.0.113.42');
+  });
+
+  test('always includes BatchMode=yes for non-interactive use', () => {
+    const args = buildSshArgs(minimalSsh);
+    const batchIdx = args.indexOf('BatchMode=yes');
+    expect(batchIdx).toBeGreaterThan(0);
+    // Preceded by -o
+    expect(args[batchIdx - 1]).toBe('-o');
+  });
+});
+
+// -- isWpCliAvailableForSite --------------------------------------------------
+
+describe('isWpCliAvailableForSite', () => {
+  test('returns true when host, user, and wpPath are all present', () => {
+    const site: SiteConfig = { ...baseSite, ssh: minimalSsh };
+    expect(isWpCliAvailableForSite(site)).toBe(true);
+  });
+
+  test('returns false when ssh is undefined', () => {
+    expect(isWpCliAvailableForSite(baseSite)).toBe(false);
+  });
+
+  test('returns false when host is empty', () => {
+    const site: SiteConfig = {
+      ...baseSite,
+      ssh: { host: '', user: 'deploy', wpPath: '/var/www/html' },
+    };
+    expect(isWpCliAvailableForSite(site)).toBe(false);
+  });
+
+  test('returns false when user is empty', () => {
+    const site: SiteConfig = {
+      ...baseSite,
+      ssh: { host: 'example.test', user: '', wpPath: '/var/www/html' },
+    };
+    expect(isWpCliAvailableForSite(site)).toBe(false);
+  });
+
+  test('returns false when wpPath is empty', () => {
+    const site: SiteConfig = {
+      ...baseSite,
+      ssh: { host: 'example.test', user: 'deploy', wpPath: '' },
+    };
+    expect(isWpCliAvailableForSite(site)).toBe(false);
+  });
+
+  test('returns true with all optional fields populated', () => {
+    const site: SiteConfig = { ...baseSite, ssh: fullSsh };
+    expect(isWpCliAvailableForSite(site)).toBe(true);
+  });
+});
+
+// -- AdapterResolver with SSH configs -----------------------------------------
+
+describe('AdapterResolver SSH integration', () => {
+  test('site without SSH only has REST adapter', () => {
+    const resolver = new AdapterResolver(baseSite);
+    const avail = resolver.availability();
+    expect(avail.rest).toBe(true);
+    expect(avail.wpCli).toBe(false);
+  });
+
+  test('site with valid SSH has both adapters', () => {
+    const site: SiteConfig = { ...baseSite, ssh: minimalSsh };
+    const resolver = new AdapterResolver(site);
+    const avail = resolver.availability();
+    expect(avail.rest).toBe(true);
+    expect(avail.wpCli).toBe(true);
+  });
+
+  test('site with incomplete SSH (missing user) only has REST', () => {
+    const site: SiteConfig = {
+      ...baseSite,
+      ssh: { host: 'example.test', user: '', wpPath: '/var/www/html' },
+    };
+    const resolver = new AdapterResolver(site);
+    const avail = resolver.availability();
+    expect(avail.rest).toBe(true);
+    expect(avail.wpCli).toBe(false);
+  });
+
+  test('site with incomplete SSH (missing wpPath) only has REST', () => {
+    const site: SiteConfig = {
+      ...baseSite,
+      ssh: { host: 'example.test', user: 'deploy', wpPath: '' },
+    };
+    const resolver = new AdapterResolver(site);
+    const avail = resolver.availability();
+    expect(avail.wpCli).toBe(false);
+  });
+
+  test('WP-CLI capabilities are unavailable without SSH', () => {
+    const resolver = new AdapterResolver(baseSite);
+    expect(resolver.tryResolve('replace-in-place')).toBeNull();
+    expect(resolver.tryResolve('regenerate-thumbnails')).toBeNull();
+    expect(resolver.tryResolve('prune-orphans')).toBeNull();
+    expect(resolver.tryResolve('full-references')).toBeNull();
+  });
+
+  test('WP-CLI capabilities are available with SSH', () => {
+    const site: SiteConfig = { ...baseSite, ssh: minimalSsh };
+    const resolver = new AdapterResolver(site);
+    expect(resolver.tryResolve('replace-in-place')?.name).toBe('wp-cli');
+    expect(resolver.tryResolve('regenerate-thumbnails')?.name).toBe('wp-cli');
+    expect(resolver.tryResolve('prune-orphans')?.name).toBe('wp-cli');
+    expect(resolver.tryResolve('full-references')?.name).toBe('wp-cli');
+  });
+
+  test('capabilityReport shows all capabilities available with SSH', () => {
+    const site: SiteConfig = { ...baseSite, ssh: fullSsh };
+    const resolver = new AdapterResolver(site);
+    const report = resolver.capabilityReport();
+    const unavailable = report.filter((r) => r.preferredAdapter === null);
+    expect(unavailable).toHaveLength(0);
+  });
+
+  test('capabilityReport shows missing capabilities without SSH', () => {
+    const resolver = new AdapterResolver(baseSite);
+    const report = resolver.capabilityReport();
+    const unavailable = report.filter((r) => r.preferredAdapter === null);
+    expect(unavailable.length).toBeGreaterThan(0);
+    const unavailableNames = unavailable.map((r) => r.capability);
+    expect(unavailableNames).toContain('replace-in-place');
+    expect(unavailableNames).toContain('regenerate-thumbnails');
+  });
+});


### PR DESCRIPTION
## Summary

Adds SSH configuration as an interactive step in the `localpress init` wizard and introduces an explicit `user` field to `SshConfig` for clearer configuration.

Previously, configuring SSH for WP-CLI required manually editing `config.json` after running `init`, and the SSH user had to be embedded in the `host` field as `user@hostname`. Now the wizard walks users through SSH setup immediately after REST authentication succeeds.

## Changes

### SSH Config Type (`src/types.ts`)
- Added explicit `user` field to `SshConfig` (required)
- `host` is now just the hostname/IP — no more `user@host` format needed
- Backward compatible: legacy `user@host` in the `host` field still works

### SSH Adapter (`src/adapters/ssh.ts`)
- New `sshDestination()` helper builds `user@host` from separate fields
- Handles legacy configs where `user@` is already in the host string
- Exported `sshDestination` and `buildSshArgs` for unit testing

### Init Wizard (`src/cli/components/InitWizard.tsx`)
After REST authentication and capability report, the wizard now:
1. Asks "Configure SSH now? [y/N]" (only when capabilities are missing)
2. Prompts for: host, user, port, wpPath, identityFile
3. Tests SSH connection (verifies `wp --info` and `wp-config.php`)
4. Shows updated capability report with all capabilities unlocked
5. Saves SSH config to the site entry

### Tests (`test/unit/ssh.test.ts`)
25 new unit tests covering:
- `sshDestination()` — user@host building, legacy compat, subdomains
- `buildSshArgs()` — port flags, identity file, BatchMode, arg ordering
- `isWpCliAvailableForSite()` — all required field combinations
- `AdapterResolver` — SSH integration with various config shapes

### Wiki Documentation
- `.wiki/WP-CLI-SSH-Setup.md` — rewritten with explicit field docs, hosting examples, troubleshooting table
- `.wiki/Configuration.md` — updated example config and SSH section

## Testing

```
bun test test/unit/  →  61 pass, 0 fail
bun run typecheck    →  clean
bun run lint         →  clean
```
