### PR TITLE
feat: enhance `stats` with full library health dashboard

### DIFF
--- a/src/cli/commands/stats.ts
+++ b/src/cli/commands/stats.ts
@@ -1,11 +1,24 @@
 /**
- * `localpress stats` — cumulative savings and processing history dashboard.
+ * `localpress stats` — cumulative savings and library health dashboard.
  *
  * Reads entirely from the local SQLite database — no network calls.
  * Falls back gracefully when no history exists yet.
+ *
+ * Shows:
+ *   - Library overview (total attachments, size, optimized %)
+ *   - Cumulative savings (bytes saved, average compression)
+ *   - Format breakdown (JPEG, PNG, WebP, AVIF counts)
+ *   - Operation breakdown (optimize, convert, resize, remove-bg)
+ *   - Recent operations (grouped by date)
  */
 
 import type { Command } from 'commander';
+import type {
+  FormatCount,
+  LibraryOverview,
+  RecentOperation,
+  SiteStats,
+} from '../../engine/state/db.ts';
 import { SiteDb } from '../../engine/state/db.ts';
 import { getSiteDbPath, loadConfig, resolveActiveSite } from '../utils/config.ts';
 import { error, info, printJson } from '../utils/output.ts';
@@ -13,7 +26,7 @@ import { error, info, printJson } from '../utils/output.ts';
 export function registerStatsCommand(program: Command): void {
   program
     .command('stats')
-    .description('Show cumulative processing stats for the active site')
+    .description('Show cumulative processing stats and library health for the active site')
     .option('--all-sites', 'show stats for every configured site')
     .action(async (options) => {
       const parentOpts = program.opts();
@@ -40,8 +53,12 @@ export function registerStatsCommand(program: Command): void {
         }
 
         const stats = db.getStats(site.name);
+        const overview = db.getLibraryOverview(site.name);
+        const formats = db.getFormatBreakdown(site.name);
+        const recent = db.getRecentOperations(site.name, 10);
         db.close();
-        results.push({ site: site.name, stats });
+
+        results.push({ site: site.name, url: site.url, stats, overview, formats, recent });
       }
 
       if (parentOpts.json) {
@@ -49,50 +66,92 @@ export function registerStatsCommand(program: Command): void {
         return;
       }
 
-      for (const { site, stats, error: err } of results as Array<{
+      for (const result of results as Array<{
         site: string;
-        stats?: import('../../engine/state/db.ts').SiteStats;
+        url?: string;
+        stats?: SiteStats;
+        overview?: LibraryOverview;
+        formats?: FormatCount[];
+        recent?: RecentOperation[];
         error?: string;
       }>) {
-        if (err || !stats) {
-          error(`${site}: ${err ?? 'no data'}`);
+        if (result.error || !result.stats) {
+          error(`${result.site}: ${result.error ?? 'no data'}`);
           continue;
         }
+
+        const { stats, overview, formats, recent } = result;
 
         if (results.length > 1) {
-          info(`\n── ${site} ──────────────────────────────`);
+          info(`\n── ${result.site} ──────────────────────────────`);
         }
 
-        if (stats.totalOps === 0) {
+        // Header
+        info(`\nSite: ${result.site} (${result.url ?? ''})`);
+        info('');
+
+        // Library overview
+        if (overview && overview.totalAttachments > 0) {
+          const optimizedPct =
+            overview.totalAttachments > 0
+              ? ((overview.optimized / overview.totalAttachments) * 100).toFixed(1)
+              : '0.0';
+
+          info('  Library:');
+          info(`    Total attachments:   ${overview.totalAttachments.toLocaleString()}`);
+          info(`    Total size:          ${formatBytes(overview.totalSizeBytes)}`);
           info(
-            `No processing history yet for "${site}". Run localpress optimize, convert, resize, or remove-bg to start.`,
+            `    Optimized:           ${overview.optimized.toLocaleString()} (${optimizedPct}%)`,
           );
-          continue;
+          info(`    Unoptimized:         ${overview.unoptimized.toLocaleString()}`);
+          info('');
         }
 
-        const saved = formatBytes(stats.bytesSaved);
-        const pct =
-          stats.bytesIn > 0
-            ? ` (${((stats.bytesSaved / stats.bytesIn) * 100).toFixed(1)}% reduction)`
-            : '';
-        const lastRan = stats.lastRanAt
-          ? new Date(stats.lastRanAt).toLocaleDateString('en-US', {
-              month: 'short',
-              day: 'numeric',
-              year: 'numeric',
-            })
-          : '—';
+        // Cumulative savings
+        if (stats.totalOps > 0) {
+          const saved = formatBytes(stats.bytesSaved);
+          const avgPct =
+            stats.bytesIn > 0 ? ((stats.bytesSaved / stats.bytesIn) * 100).toFixed(1) : '0.0';
+          const lastRan = stats.lastRanAt
+            ? new Date(stats.lastRanAt).toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+              })
+            : '—';
 
-        info(`\n  Site            ${site}`);
-        info(`  Files touched   ${stats.filesTouched.toLocaleString()}`);
-        info(
-          `  Operations      ${stats.succeeded.toLocaleString()} succeeded  /  ${(stats.totalOps - stats.succeeded).toLocaleString()} failed`,
-        );
-        info(`  Bytes saved     ${saved}${pct}`);
-        info(`  Last run        ${lastRan}`);
+          info('  Processing:');
+          info(
+            `    Cumulative savings:  ${saved} across ${stats.filesTouched.toLocaleString()} attachments`,
+          );
+          info(`    Average compression: ${avgPct}%`);
+          info(
+            `    Operations:          ${stats.succeeded.toLocaleString()} succeeded / ${(stats.totalOps - stats.succeeded).toLocaleString()} failed`,
+          );
+          info(`    Last run:            ${lastRan}`);
+          info('');
+        } else {
+          info(
+            '  No processing history yet. Run localpress optimize, convert, resize, or remove-bg to start.',
+          );
+          info('');
+        }
 
+        // Format breakdown
+        if (formats && formats.length > 0) {
+          const total = formats.reduce((sum, f) => sum + f.count, 0);
+          info('  Format breakdown:');
+          for (const f of formats) {
+            const pct = ((f.count / total) * 100).toFixed(1);
+            const label = formatMimeType(f.mimeType).padEnd(8);
+            info(`    ${label} ${f.count.toLocaleString().padStart(6)}  (${pct}%)`);
+          }
+          info('');
+        }
+
+        // Operation breakdown
         if (stats.byOperation.length > 0) {
-          info('\n  Breakdown by operation:\n');
+          info('  By operation:');
           const colW = Math.max(...stats.byOperation.map((o) => o.operation.length)) + 2;
           for (const op of stats.byOperation) {
             const name = op.operation.padEnd(colW);
@@ -101,16 +160,43 @@ export function registerStatsCommand(program: Command): void {
             const avg = op.avgDurationMs ? `  avg ${op.avgDurationMs}ms` : '';
             info(`    ${name}${count} ops${opSaved}${avg}`);
           }
+          info('');
         }
 
-        info('');
+        // Recent operations
+        if (recent && recent.length > 0) {
+          info('  Recent operations:');
+          for (const r of recent) {
+            const savedStr = r.bytesSaved > 0 ? `  saved ${formatBytes(r.bytesSaved)}` : '';
+            info(
+              `    ${r.date}  ${r.operation.padEnd(12)} ${String(r.itemCount).padStart(4)} items${savedStr}`,
+            );
+          }
+          info('');
+        }
       }
     });
 }
+
+// -- Helpers ------------------------------------------------------------------
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatMimeType(mime: string): string {
+  const map: Record<string, string> = {
+    'image/jpeg': 'JPEG',
+    'image/png': 'PNG',
+    'image/webp': 'WebP',
+    'image/avif': 'AVIF',
+    'image/gif': 'GIF',
+    'image/svg+xml': 'SVG',
+    'application/pdf': 'PDF',
+    'video/mp4': 'MP4',
+  };
+  return map[mime] ?? mime.replace('image/', '').replace('application/', '').toUpperCase();
 }

--- a/src/engine/state/db.ts
+++ b/src/engine/state/db.ts
@@ -265,6 +265,85 @@ export class SiteDb {
     };
   }
 
+  // Library overview -----------------------------------------------------------
+
+  /** Get total attachment count and total size for a site. */
+  getLibraryOverview(siteName: string): LibraryOverview {
+    const row = this.db
+      .query(
+        `SELECT COUNT(*)          AS total_attachments,
+                COALESCE(SUM(size_bytes), 0) AS total_size_bytes
+         FROM attachments
+         WHERE site_name = ?`,
+      )
+      .get(siteName) as { total_attachments: number; total_size_bytes: number } | null;
+
+    const processedCount = this.db
+      .query(
+        `SELECT COUNT(DISTINCT wp_id) AS optimized
+         FROM processing_history
+         WHERE site_name = ? AND status = 'success'`,
+      )
+      .get(siteName) as { optimized: number } | null;
+
+    const totalAttachments = row?.total_attachments ?? 0;
+    const optimized = processedCount?.optimized ?? 0;
+
+    return {
+      totalAttachments,
+      totalSizeBytes: row?.total_size_bytes ?? 0,
+      optimized,
+      unoptimized: totalAttachments - optimized,
+    };
+  }
+
+  /** Get format breakdown (MIME type counts) for a site. */
+  getFormatBreakdown(siteName: string): FormatCount[] {
+    const rows = this.db
+      .query(
+        `SELECT mime_type, COUNT(*) AS count
+         FROM attachments
+         WHERE site_name = ? AND mime_type IS NOT NULL
+         GROUP BY mime_type
+         ORDER BY count DESC`,
+      )
+      .all(siteName) as Array<{ mime_type: string; count: number }>;
+
+    return rows.map((r) => ({
+      mimeType: r.mime_type,
+      count: r.count,
+    }));
+  }
+
+  /** Get recent operations grouped by date and operation type. */
+  getRecentOperations(siteName: string, limit = 10): RecentOperation[] {
+    const rows = this.db
+      .query(
+        `SELECT DATE(ran_at / 1000, 'unixepoch') AS date,
+                operation,
+                COUNT(*)                          AS item_count,
+                SUM(CASE WHEN bytes_before > bytes_after THEN bytes_before - bytes_after ELSE 0 END) AS bytes_saved
+         FROM processing_history
+         WHERE site_name = ? AND status = 'success'
+         GROUP BY date, operation
+         ORDER BY date DESC, item_count DESC
+         LIMIT ?`,
+      )
+      .all(siteName, limit) as Array<{
+      date: string;
+      operation: string;
+      item_count: number;
+      bytes_saved: number | null;
+    }>;
+
+    return rows.map((r) => ({
+      date: r.date,
+      operation: r.operation,
+      itemCount: r.item_count,
+      bytesSaved: r.bytes_saved ?? 0,
+    }));
+  }
+
   // Lifecycle -----------------------------------------------------------------
 
   close(): void {
@@ -402,6 +481,27 @@ interface RawTotalStat {
   total_ops: number;
   succeeded: number;
   last_ran_at: number | null;
+}
+
+// -- Library overview types ---------------------------------------------------
+
+export interface LibraryOverview {
+  totalAttachments: number;
+  totalSizeBytes: number;
+  optimized: number;
+  unoptimized: number;
+}
+
+export interface FormatCount {
+  mimeType: string;
+  count: number;
+}
+
+export interface RecentOperation {
+  date: string;
+  operation: string;
+  itemCount: number;
+  bytesSaved: number;
 }
 
 /** Read the current schema version stored in the DB. Returns 0 if no version row exists. */

--- a/test/unit/stats.test.ts
+++ b/test/unit/stats.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Unit tests for the stats dashboard database methods.
+ *
+ * Tests getLibraryOverview, getFormatBreakdown, and getRecentOperations
+ * against an in-memory SQLite database with seeded data.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import { SiteDb } from '../../src/engine/state/db.ts';
+
+const SITE_NAME = 'test-site';
+const SITE_URL = 'https://example.test';
+
+let db: SiteDb;
+
+beforeEach(() => {
+  db = SiteDb.init(':memory:');
+  db.ensureSite(SITE_NAME, SITE_URL);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+// -- Helpers ------------------------------------------------------------------
+
+function seedAttachments(
+  items: Array<{ wpId: number; mimeType: string; sizeBytes: number }>,
+): void {
+  for (const item of items) {
+    db.upsertAttachment({
+      siteName: SITE_NAME,
+      wpId: item.wpId,
+      sourceUrl: `https://example.test/wp-content/uploads/img-${item.wpId}.jpg`,
+      sourceHash: `hash-${item.wpId}`,
+      sizeBytes: item.sizeBytes,
+      width: 1920,
+      height: 1080,
+      mimeType: item.mimeType,
+      lastSeenAt: Date.now(),
+    });
+  }
+}
+
+function seedProcessing(
+  items: Array<{
+    wpId: number;
+    operation: string;
+    bytesBefore: number;
+    bytesAfter: number;
+    ranAt?: number;
+    status?: 'success' | 'failure';
+  }>,
+): void {
+  for (const item of items) {
+    db.recordProcessing({
+      siteName: SITE_NAME,
+      wpId: item.wpId,
+      operation: item.operation,
+      paramsJson: null,
+      sourceHash: `hash-${item.wpId}`,
+      resultHash: `result-${item.wpId}`,
+      bytesBefore: item.bytesBefore,
+      bytesAfter: item.bytesAfter,
+      resultWpId: null,
+      ranAt: item.ranAt ?? Date.now(),
+      durationMs: 150,
+      status: item.status ?? 'success',
+      errorMessage: null,
+    });
+  }
+}
+
+// -- getLibraryOverview -------------------------------------------------------
+
+describe('getLibraryOverview', () => {
+  test('returns zeros when no attachments exist', () => {
+    const overview = db.getLibraryOverview(SITE_NAME);
+    expect(overview.totalAttachments).toBe(0);
+    expect(overview.totalSizeBytes).toBe(0);
+    expect(overview.optimized).toBe(0);
+    expect(overview.unoptimized).toBe(0);
+  });
+
+  test('counts total attachments and size', () => {
+    seedAttachments([
+      { wpId: 1, mimeType: 'image/jpeg', sizeBytes: 500_000 },
+      { wpId: 2, mimeType: 'image/png', sizeBytes: 300_000 },
+      { wpId: 3, mimeType: 'image/webp', sizeBytes: 200_000 },
+    ]);
+
+    const overview = db.getLibraryOverview(SITE_NAME);
+    expect(overview.totalAttachments).toBe(3);
+    expect(overview.totalSizeBytes).toBe(1_000_000);
+  });
+
+  test('correctly identifies optimized vs unoptimized', () => {
+    seedAttachments([
+      { wpId: 1, mimeType: 'image/jpeg', sizeBytes: 500_000 },
+      { wpId: 2, mimeType: 'image/png', sizeBytes: 300_000 },
+      { wpId: 3, mimeType: 'image/webp', sizeBytes: 200_000 },
+    ]);
+
+    // Only process items 1 and 2
+    seedProcessing([
+      { wpId: 1, operation: 'optimize', bytesBefore: 500_000, bytesAfter: 300_000 },
+      { wpId: 2, operation: 'optimize', bytesBefore: 300_000, bytesAfter: 150_000 },
+    ]);
+
+    const overview = db.getLibraryOverview(SITE_NAME);
+    expect(overview.optimized).toBe(2);
+    expect(overview.unoptimized).toBe(1);
+  });
+
+  test('failed operations do not count as optimized', () => {
+    seedAttachments([
+      { wpId: 1, mimeType: 'image/jpeg', sizeBytes: 500_000 },
+      { wpId: 2, mimeType: 'image/png', sizeBytes: 300_000 },
+    ]);
+
+    seedProcessing([
+      { wpId: 1, operation: 'optimize', bytesBefore: 500_000, bytesAfter: 300_000 },
+      {
+        wpId: 2,
+        operation: 'optimize',
+        bytesBefore: 300_000,
+        bytesAfter: 300_000,
+        status: 'failure',
+      },
+    ]);
+
+    const overview = db.getLibraryOverview(SITE_NAME);
+    expect(overview.optimized).toBe(1);
+    expect(overview.unoptimized).toBe(1);
+  });
+});
+
+// -- getFormatBreakdown -------------------------------------------------------
+
+describe('getFormatBreakdown', () => {
+  test('returns empty array when no attachments exist', () => {
+    const formats = db.getFormatBreakdown(SITE_NAME);
+    expect(formats).toHaveLength(0);
+  });
+
+  test('groups by MIME type and counts correctly', () => {
+    seedAttachments([
+      { wpId: 1, mimeType: 'image/jpeg', sizeBytes: 100_000 },
+      { wpId: 2, mimeType: 'image/jpeg', sizeBytes: 200_000 },
+      { wpId: 3, mimeType: 'image/jpeg', sizeBytes: 150_000 },
+      { wpId: 4, mimeType: 'image/png', sizeBytes: 300_000 },
+      { wpId: 5, mimeType: 'image/webp', sizeBytes: 80_000 },
+      { wpId: 6, mimeType: 'image/webp', sizeBytes: 90_000 },
+    ]);
+
+    const formats = db.getFormatBreakdown(SITE_NAME);
+    expect(formats).toHaveLength(3);
+
+    // Ordered by count DESC
+    expect(formats[0].mimeType).toBe('image/jpeg');
+    expect(formats[0].count).toBe(3);
+    expect(formats[1].mimeType).toBe('image/webp');
+    expect(formats[1].count).toBe(2);
+    expect(formats[2].mimeType).toBe('image/png');
+    expect(formats[2].count).toBe(1);
+  });
+
+  test('excludes attachments with null mime_type', () => {
+    seedAttachments([{ wpId: 1, mimeType: 'image/jpeg', sizeBytes: 100_000 }]);
+    // Insert one with null mime_type directly
+    db.upsertAttachment({
+      siteName: SITE_NAME,
+      wpId: 99,
+      sourceUrl: 'https://example.test/file.bin',
+      sourceHash: null,
+      sizeBytes: 50_000,
+      width: null,
+      height: null,
+      mimeType: null,
+      lastSeenAt: Date.now(),
+    });
+
+    const formats = db.getFormatBreakdown(SITE_NAME);
+    expect(formats).toHaveLength(1);
+    expect(formats[0].mimeType).toBe('image/jpeg');
+  });
+});
+
+// -- getRecentOperations ------------------------------------------------------
+
+describe('getRecentOperations', () => {
+  test('returns empty array when no processing history exists', () => {
+    const recent = db.getRecentOperations(SITE_NAME);
+    expect(recent).toHaveLength(0);
+  });
+
+  test('groups operations by date and operation type', () => {
+    seedAttachments([
+      { wpId: 1, mimeType: 'image/jpeg', sizeBytes: 500_000 },
+      { wpId: 2, mimeType: 'image/jpeg', sizeBytes: 400_000 },
+      { wpId: 3, mimeType: 'image/png', sizeBytes: 300_000 },
+    ]);
+
+    const today = Date.now();
+    const yesterday = today - 86_400_000;
+
+    seedProcessing([
+      { wpId: 1, operation: 'optimize', bytesBefore: 500_000, bytesAfter: 300_000, ranAt: today },
+      { wpId: 2, operation: 'optimize', bytesBefore: 400_000, bytesAfter: 250_000, ranAt: today },
+      {
+        wpId: 3,
+        operation: 'convert',
+        bytesBefore: 300_000,
+        bytesAfter: 100_000,
+        ranAt: yesterday,
+      },
+    ]);
+
+    const recent = db.getRecentOperations(SITE_NAME);
+    expect(recent.length).toBeGreaterThanOrEqual(2);
+
+    // Most recent first
+    const todayOp = recent.find((r) => r.operation === 'optimize');
+    expect(todayOp).toBeDefined();
+    expect(todayOp?.itemCount).toBe(2);
+    expect(todayOp?.bytesSaved).toBe(350_000); // (500k-300k) + (400k-250k)
+  });
+
+  test('respects limit parameter', () => {
+    seedAttachments([
+      { wpId: 1, mimeType: 'image/jpeg', sizeBytes: 100_000 },
+      { wpId: 2, mimeType: 'image/jpeg', sizeBytes: 100_000 },
+      { wpId: 3, mimeType: 'image/jpeg', sizeBytes: 100_000 },
+    ]);
+
+    const day1 = Date.now() - 86_400_000 * 3;
+    const day2 = Date.now() - 86_400_000 * 2;
+    const day3 = Date.now() - 86_400_000;
+
+    seedProcessing([
+      { wpId: 1, operation: 'optimize', bytesBefore: 100_000, bytesAfter: 50_000, ranAt: day1 },
+      { wpId: 2, operation: 'convert', bytesBefore: 100_000, bytesAfter: 60_000, ranAt: day2 },
+      { wpId: 3, operation: 'resize', bytesBefore: 100_000, bytesAfter: 40_000, ranAt: day3 },
+    ]);
+
+    const recent = db.getRecentOperations(SITE_NAME, 2);
+    expect(recent).toHaveLength(2);
+  });
+
+  test('excludes failed operations', () => {
+    seedAttachments([
+      { wpId: 1, mimeType: 'image/jpeg', sizeBytes: 100_000 },
+      { wpId: 2, mimeType: 'image/jpeg', sizeBytes: 100_000 },
+    ]);
+
+    seedProcessing([
+      { wpId: 1, operation: 'optimize', bytesBefore: 100_000, bytesAfter: 50_000 },
+      {
+        wpId: 2,
+        operation: 'optimize',
+        bytesBefore: 100_000,
+        bytesAfter: 100_000,
+        status: 'failure',
+      },
+    ]);
+
+    const recent = db.getRecentOperations(SITE_NAME);
+    // Only the successful one should appear
+    const totalItems = recent.reduce((sum, r) => sum + r.itemCount, 0);
+    expect(totalItems).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #5

## Summary

Enhances the `localpress stats` command from a basic processing history summary into the full library health dashboard described in the issue. All data comes from the local SQLite database — zero network calls.

## Output

```
Site: production (https://example.com)

  Library:
    Total attachments:   847
    Total size:          4.2 GB
    Optimized:           623 (73.6%)
    Unoptimized:         224

  Processing:
    Cumulative savings:  1.2 GB across 623 attachments
    Average compression: 42.3%
    Operations:          645 succeeded / 3 failed
    Last run:            May 7, 2026

  Format breakdown:
    JPEG       412  (48.6%)
    PNG        198  (23.4%)
    WebP       187  (22.1%)
    AVIF        50  (5.9%)

  By operation:
    optimize    512 ops  saved 980.2 MB  avg 245ms
    convert      89 ops  saved 156.8 MB  avg 312ms
    resize       32 ops  saved 67.4 MB   avg 89ms
    remove-bg    12 ops                  avg 1842ms

  Recent operations:
    2026-05-07  optimize        45 items  saved 128.3 MB
    2026-05-06  convert         12 items  saved 34.1 MB
    2026-05-05  optimize        89 items  saved 312.7 MB
```

## JSON output

```bash
localpress --json stats
```

Returns all sections as structured data — library overview, format breakdown, recent operations, and the existing processing stats. Fully consumable by the skill/agent.

## Implementation

### New `SiteDb` methods (`src/engine/state/db.ts`)

- `getLibraryOverview(siteName)` — total attachments, total size, optimized count (distinct wp_ids with successful processing), unoptimized count
- `getFormatBreakdown(siteName)` — MIME type counts from the attachments table, ordered by frequency, excludes null mime_types
- `getRecentOperations(siteName, limit)` — groups successful processing history by date + operation, sums bytes saved per group

### Enhanced `stats` command (`src/cli/commands/stats.ts`)

- Library section: total attachments, total size, optimized/unoptimized with percentage
- Processing section: cumulative savings, average compression ratio, success/failure counts
- Format breakdown: human-readable MIME type labels (JPEG, PNG, WebP, AVIF, etc.)
- Operation breakdown: per-operation stats with average duration
- Recent operations: date-grouped history showing item counts and savings

## Testing

11 new unit tests covering:
- `getLibraryOverview` — empty state, counting, optimized vs unoptimized, failed ops excluded
- `getFormatBreakdown` — empty state, grouping, null mime_type exclusion
- `getRecentOperations` — empty state, date grouping, limit, failed ops excluded

```
bun test test/unit/  →  91 pass, 0 fail
bun run typecheck    →  clean
bun run lint         →  clean
```
