### PR TITLE
fix: SSH 'Too many authentication failures' when identityFile is set

### DIFF
--- a/src/adapters/ssh.ts
+++ b/src/adapters/ssh.ts
@@ -40,6 +40,7 @@ export async function scpUpload(
   }
   if (ssh.identityFile) {
     args.push('-i', ssh.identityFile);
+    args.push('-o', 'IdentitiesOnly=yes');
   }
 
   // Disable strict host key checking for non-interactive use.
@@ -67,6 +68,7 @@ export async function scpDownload(
   }
   if (ssh.identityFile) {
     args.push('-i', ssh.identityFile);
+    args.push('-o', 'IdentitiesOnly=yes');
   }
 
   args.push('-o', 'StrictHostKeyChecking=accept-new');
@@ -99,6 +101,9 @@ export function buildSshArgs(ssh: SshConfig): string[] {
   }
   if (ssh.identityFile) {
     args.push('-i', ssh.identityFile);
+    // Only use the specified key — don't let the agent offer all its keys first,
+    // which causes "Too many authentication failures" on servers with low MaxAuthTries.
+    args.push('-o', 'IdentitiesOnly=yes');
   }
 
   // Disable strict host key checking for non-interactive use.

--- a/test/unit/ssh.test.ts
+++ b/test/unit/ssh.test.ts
@@ -93,6 +93,8 @@ describe('buildSshArgs', () => {
     expect(args).not.toContain('-p');
     // No -i flag without identityFile
     expect(args).not.toContain('-i');
+    // No IdentitiesOnly without identityFile (allows agent to work normally)
+    expect(args).not.toContain('IdentitiesOnly=yes');
   });
 
   test('custom port adds -p flag', () => {
@@ -108,11 +110,13 @@ describe('buildSshArgs', () => {
     expect(args).not.toContain('-p');
   });
 
-  test('identityFile adds -i flag', () => {
+  test('identityFile adds -i flag and IdentitiesOnly=yes', () => {
     const args = buildSshArgs(fullSsh);
     const iIdx = args.indexOf('-i');
     expect(iIdx).toBeGreaterThanOrEqual(0);
     expect(args[iIdx + 1]).toBe('~/.ssh/id_ed25519');
+    // IdentitiesOnly prevents agent from offering all keys
+    expect(args).toContain('IdentitiesOnly=yes');
   });
 
   test('destination is always the last argument', () => {


### PR DESCRIPTION
## Problem

When `identityFile` is configured in the SSH config, SSH still offers every key from the agent first. Servers with low `MaxAuthTries` (default 6) disconnect before the specified key is ever tried:

```
error: WP-CLI error (exit 255): Received disconnect from 188.166.19.111 port 22:2: Too many authentication failures
```

## Root Cause

The `-i <keyfile>` flag tells SSH to *also* try that key, but doesn't prevent the agent from offering all its other keys first. If you have 6+ keys in your agent, the server gives up before reaching yours.

## Fix

Add `-o IdentitiesOnly=yes` alongside `-i <keyfile>` in all SSH/SCP functions. This tells SSH to *only* use the specified key, ignoring the agent's key list.

Applied in:
- `buildSshArgs()` (used by `sshExec`)
- `scpUpload()`
- `scpDownload()`

Only added when `identityFile` is configured — when no key is specified, the agent works normally.

## Testing

Updated existing test to verify `IdentitiesOnly=yes` is present when `identityFile` is set, and added assertion that it's absent when no identity file is configured.

```
bun test test/unit/ssh.test.ts  →  25 pass, 0 fail
bun run typecheck               →  clean
bun run lint                    →  clean
```