### PR TITLE
fix: prefer REST over WP-CLI for read operations (list hangs with SSH)

### DIFF
--- a/src/adapters/resolver.ts
+++ b/src/adapters/resolver.ts
@@ -32,6 +32,20 @@ export interface CapabilityReport {
 /** Preference order for adapters when multiple support a capability. */
 const ADAPTER_PRIORITY: WpBackend['name'][] = ['wp-cli', 'rest'];
 
+/**
+ * Capabilities where REST is preferred over WP-CLI even when both are available.
+ * REST is a single HTTP request; WP-CLI over SSH has per-item round-trip overhead
+ * that makes read-heavy operations painfully slow.
+ */
+const REST_PREFERRED: ReadonlySet<Capability> = new Set<Capability>([
+  'list',
+  'get',
+  'upload',
+  'update-meta',
+  'delete',
+  'fast-references',
+]);
+
 const ALL_CAPABILITIES: Capability[] = [
   'list',
   'get',
@@ -64,7 +78,11 @@ export class AdapterResolver {
    * Throws if no adapter supports it.
    */
   resolve(capability: Capability): WpBackend {
-    for (const name of ADAPTER_PRIORITY) {
+    const priority = REST_PREFERRED.has(capability)
+      ? (['rest', 'wp-cli'] as const)
+      : ADAPTER_PRIORITY;
+
+    for (const name of priority) {
       const adapter = this.adapters.find((a) => a.name === name);
       if (adapter?.capabilities.has(capability)) {
         return adapter;
@@ -75,7 +93,11 @@ export class AdapterResolver {
 
   /** Same as resolve(), but returns null instead of throwing. */
   tryResolve(capability: Capability): WpBackend | null {
-    for (const name of ADAPTER_PRIORITY) {
+    const priority = REST_PREFERRED.has(capability)
+      ? (['rest', 'wp-cli'] as const)
+      : ADAPTER_PRIORITY;
+
+    for (const name of priority) {
       const adapter = this.adapters.find((a) => a.name === name);
       if (adapter?.capabilities.has(capability)) {
         return adapter;

--- a/test/unit/smoke.test.ts
+++ b/test/unit/smoke.test.ts
@@ -77,13 +77,20 @@ describe('AdapterResolver', () => {
     expect(adapter?.name).toBe('wp-cli');
   });
 
-  test('REST adapter is preferred for cheap operations even when WP-CLI is available', () => {
-    // List is supported by both; preference order says wp-cli wins, but
-    // the resolver currently picks WP-CLI first per priority.
-    // If we ever want REST-first for cheap ops, this test will catch the change.
+  test('REST adapter is preferred for read operations even when WP-CLI is available', () => {
+    // REST is faster for reads (single HTTP request vs per-item SSH round-trips).
+    // WP-CLI is only preferred for operations REST can't do.
     const resolver = new AdapterResolver(fakeWpCliSite);
-    const adapter = resolver.tryResolve('list');
-    expect(adapter?.name).toBe('wp-cli');
+    expect(resolver.tryResolve('list')?.name).toBe('rest');
+    expect(resolver.tryResolve('get')?.name).toBe('rest');
+    expect(resolver.tryResolve('fast-references')?.name).toBe('rest');
+  });
+
+  test('WP-CLI is preferred for server-side operations', () => {
+    const resolver = new AdapterResolver(fakeWpCliSite);
+    expect(resolver.tryResolve('replace-in-place')?.name).toBe('wp-cli');
+    expect(resolver.tryResolve('regenerate-thumbnails')?.name).toBe('wp-cli');
+    expect(resolver.tryResolve('full-references')?.name).toBe('wp-cli');
   });
 
   test('capabilityReport covers all Capability values', () => {


### PR DESCRIPTION
## Problem

`localpress list -i` hangs indefinitely when SSH is configured. Without the `ssh` block in config, it loads in 3-8 seconds. With SSH configured, it never renders.

## Root Cause

The adapter resolver used a global priority order (`wp-cli > rest`) for ALL capabilities. When SSH was configured, `list` operations routed through WP-CLI, which:

1. Makes one SSH call to list posts
2. Makes **one SSH call per post** to enrich metadata (`wp post meta get` + `wp post get`)

With 50 items per page, that's 100+ sequential SSH round-trips. Each has TCP + key exchange overhead. Result: minutes of latency instead of a single REST API call.

## Fix

Per-capability priority instead of global priority:

- **REST preferred** for: `list`, `get`, `upload`, `update-meta`, `delete`, `fast-references` (single HTTP request, fast)
- **WP-CLI preferred** for: `replace-in-place`, `regenerate-thumbnails`, `prune-orphans`, `full-references` (operations REST can't do)

This means SSH config only activates for operations that actually need server-side access. Read operations always use REST regardless of SSH configuration.

## Testing

```
bun test test/unit/  →  92 pass, 0 fail
bun run typecheck    →  clean
bun run lint         →  clean
```

Updated tests to verify REST is preferred for reads and WP-CLI for server-side ops.
