### PR TITLE
feat: loading spinner for `list -i` initial fetch

### DIFF
--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -129,13 +129,22 @@ export function registerListCommand(program: Command): void {
         // Loop: re-enter the TUI after each subcommand until the user quits.
         while (true) {
           let result: { items: MediaItem[]; total: number; totalPages: number };
+
+          // Show a loading spinner while fetching the page.
+          const spinner = render(
+            React.default.createElement(InkText, { color: 'cyan' }, '⠋ Loading media library...'),
+          );
+
           try {
             result = await adapter.listMediaPage({ ...filters, page: interactivePage });
           } catch (err) {
+            spinner.unmount();
             error(err instanceof Error ? err.message : String(err));
             process.exit(4);
             return;
           }
+
+          spinner.unmount();
 
           if (result.items.length === 0 && interactivePage === 1) {
             info('No media items found.');


### PR DESCRIPTION
## Problem

When running `localpress list -i`, the terminal is completely blank for 3-8 seconds while the REST API fetches the first page of media. This makes it look like the command has hung, especially for users who just configured SSH and saw the previous hang behavior.

## Fix

Renders a cyan "⠋ Loading media library..." message via Ink while the initial `listMediaPage()` call is in flight. The spinner is unmounted as soon as data arrives, before the MediaBrowser component renders.

Only applies to interactive mode (`-i`). Plain and JSON modes are unaffected.

## Testing

```
bun run typecheck  →  clean
bun run lint       →  clean
bun test test/unit →  92 pass
```

Manually verified: the loading message appears immediately on `list -i` and disappears when the list renders.
