### PR TITLE
fix: `list -i` subcommand dispatch 'Script not found' error

### DIFF
--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -60,16 +60,11 @@ export function registerListCommand(program: Command): void {
         const { useState: useReactState, useEffect: useReactEffect } = React.default;
         const { MediaBrowser } = await import('../components/MediaBrowser.tsx');
         const { spawnSync } = await import('node:child_process');
+        const { getSelfBin, buildSelfArgs } = await import('../utils/self-invoke.ts');
 
-        // argv[1] is a .ts script in dev mode; the compiled binary repeats argv[0].
-        // In compiled mode, process.argv[0] IS the binary — just re-invoke it directly.
-        // In dev mode (bun run src/cli/index.ts), we need to pass the script path.
-        const isDevMode =
-          /\.(ts|mts|js|mjs)$/.test(process.argv[1] ?? '') &&
-          !process.execPath.includes('localpress');
-        const selfBin = isDevMode ? process.argv[0] : process.execPath;
+        const selfBin = getSelfBin(process.argv, process.execPath);
         const selfArgs = (cmd: string, id: string, extra: string[] = []) =>
-          isDevMode ? [process.argv[1], cmd, id, ...extra] : [cmd, id, ...extra];
+          buildSelfArgs(process.argv, process.execPath, cmd, id, extra);
 
         const { spawn: spawnBg } = await import('node:child_process');
         const openInBrowser = (id: number) => {

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -62,7 +62,12 @@ export function registerListCommand(program: Command): void {
         const { spawnSync } = await import('node:child_process');
 
         // argv[1] is a .ts script in dev mode; the compiled binary repeats argv[0].
-        const isDevMode = /\.(ts|mts|js|mjs)$/.test(process.argv[1] ?? '');
+        // In compiled mode, process.argv[0] IS the binary — just re-invoke it directly.
+        // In dev mode (bun run src/cli/index.ts), we need to pass the script path.
+        const isDevMode =
+          /\.(ts|mts|js|mjs)$/.test(process.argv[1] ?? '') &&
+          !process.execPath.includes('localpress');
+        const selfBin = isDevMode ? process.argv[0] : process.execPath;
         const selfArgs = (cmd: string, id: string, extra: string[] = []) =>
           isDevMode ? [process.argv[1], cmd, id, ...extra] : [cmd, id, ...extra];
 
@@ -263,7 +268,7 @@ export function registerListCommand(program: Command): void {
               subCmd = 'edit';
           }
 
-          spawnSync(process.argv[0], selfArgs(subCmd, String(pendingAction.id), extraArgs), {
+          spawnSync(selfBin, selfArgs(subCmd, String(pendingAction.id), extraArgs), {
             stdio: 'inherit',
           });
 

--- a/src/cli/utils/self-invoke.ts
+++ b/src/cli/utils/self-invoke.ts
@@ -1,0 +1,53 @@
+/**
+ * Helpers for re-invoking the localpress binary from within the interactive TUI.
+ *
+ * When the interactive browser dispatches a subcommand (optimize, edit, etc.),
+ * it needs to spawn a child process that runs `localpress <cmd> <id>`. The
+ * challenge: in dev mode we're running via `bun src/cli/index.ts`, but in
+ * compiled mode `process.argv[0]` may point to `bun` rather than the binary.
+ *
+ * These helpers detect the execution mode and return the correct binary path
+ * and argument array for spawning subcommands.
+ */
+
+/**
+ * Detect whether we're running in dev mode (bun src/cli/index.ts) vs
+ * a compiled binary (localpress).
+ */
+export function isDevMode(argv: string[], execPath: string): boolean {
+  // In dev mode, argv[1] is a .ts/.js script file.
+  // In compiled mode, Bun may embed the source path in argv[1], but
+  // execPath will contain 'localpress' (the compiled binary name).
+  const hasScriptArg = /\.(ts|mts|js|mjs)$/.test(argv[1] ?? '');
+  const isCompiledBinary = execPath.includes('localpress');
+  return hasScriptArg && !isCompiledBinary;
+}
+
+/**
+ * Get the binary path to use when spawning subcommands.
+ *
+ * - Dev mode: use argv[0] (typically `bun`)
+ * - Compiled mode: use execPath (the actual binary)
+ */
+export function getSelfBin(argv: string[], execPath: string): string {
+  return isDevMode(argv, execPath) ? argv[0] : execPath;
+}
+
+/**
+ * Build the argument array for spawning a subcommand.
+ *
+ * - Dev mode: [scriptPath, cmd, id, ...extra]
+ * - Compiled mode: [cmd, id, ...extra]
+ */
+export function buildSelfArgs(
+  argv: string[],
+  execPath: string,
+  cmd: string,
+  id: string,
+  extra: string[] = [],
+): string[] {
+  if (isDevMode(argv, execPath)) {
+    return [argv[1], cmd, id, ...extra];
+  }
+  return [cmd, id, ...extra];
+}

--- a/test/unit/self-invoke.test.ts
+++ b/test/unit/self-invoke.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for the self-invoke utility.
+ *
+ * Verifies correct binary path and argument construction for both
+ * dev mode (bun src/cli/index.ts) and compiled binary mode (localpress).
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { buildSelfArgs, getSelfBin, isDevMode } from '../../src/cli/utils/self-invoke.ts';
+
+// -- isDevMode ----------------------------------------------------------------
+
+describe('isDevMode', () => {
+  test('returns true when argv[1] is a .ts file and execPath is bun', () => {
+    const argv = ['/usr/local/bin/bun', 'src/cli/index.ts', 'list', '-i'];
+    expect(isDevMode(argv, '/usr/local/bin/bun')).toBe(true);
+  });
+
+  test('returns true when argv[1] is a .mts file', () => {
+    const argv = ['/usr/local/bin/bun', 'src/cli/index.mts', 'list'];
+    expect(isDevMode(argv, '/usr/local/bin/bun')).toBe(true);
+  });
+
+  test('returns true when argv[1] is a .js file', () => {
+    const argv = ['/usr/local/bin/node', 'dist/index.js', 'list'];
+    expect(isDevMode(argv, '/usr/local/bin/node')).toBe(true);
+  });
+
+  test('returns false when execPath contains localpress (compiled binary)', () => {
+    // Compiled Bun binaries may still have .ts in argv[1] (embedded source path)
+    const argv = ['/usr/local/bin/localpress', 'src/cli/index.ts', 'list', '-i'];
+    expect(isDevMode(argv, '/usr/local/bin/localpress')).toBe(false);
+  });
+
+  test('returns false when execPath is a Homebrew localpress path', () => {
+    const argv = ['/opt/homebrew/Cellar/localpress/1.8.1/bin/localpress', 'list', '-i'];
+    expect(isDevMode(argv, '/opt/homebrew/Cellar/localpress/1.8.1/bin/localpress')).toBe(false);
+  });
+
+  test('returns false when argv[1] is a subcommand (not a script file)', () => {
+    const argv = ['/usr/local/bin/localpress', 'list', '-i'];
+    expect(isDevMode(argv, '/usr/local/bin/localpress')).toBe(false);
+  });
+
+  test('returns false when argv is empty', () => {
+    expect(isDevMode([], '/usr/local/bin/bun')).toBe(false);
+  });
+
+  test('returns false when argv has only one element', () => {
+    expect(isDevMode(['/usr/local/bin/localpress'], '/usr/local/bin/localpress')).toBe(false);
+  });
+});
+
+// -- getSelfBin ---------------------------------------------------------------
+
+describe('getSelfBin', () => {
+  test('returns argv[0] in dev mode (bun)', () => {
+    const argv = ['/usr/local/bin/bun', 'src/cli/index.ts', 'list'];
+    expect(getSelfBin(argv, '/usr/local/bin/bun')).toBe('/usr/local/bin/bun');
+  });
+
+  test('returns execPath in compiled mode', () => {
+    const argv = ['/usr/local/bin/localpress', 'list', '-i'];
+    expect(getSelfBin(argv, '/usr/local/bin/localpress')).toBe('/usr/local/bin/localpress');
+  });
+
+  test('returns execPath when Homebrew-installed', () => {
+    const execPath = '/opt/homebrew/Cellar/localpress/1.8.1/bin/localpress';
+    const argv = [execPath, 'list'];
+    expect(getSelfBin(argv, execPath)).toBe(execPath);
+  });
+
+  test('returns execPath even if argv[1] looks like a script (compiled binary)', () => {
+    // Bun compiled binaries can embed the source path in argv
+    const argv = ['/usr/local/bin/localpress', 'src/cli/index.ts', 'list'];
+    expect(getSelfBin(argv, '/usr/local/bin/localpress')).toBe('/usr/local/bin/localpress');
+  });
+});
+
+// -- buildSelfArgs ------------------------------------------------------------
+
+describe('buildSelfArgs', () => {
+  test('dev mode: includes script path before command', () => {
+    const argv = ['/usr/local/bin/bun', 'src/cli/index.ts', 'list', '-i'];
+    const args = buildSelfArgs(argv, '/usr/local/bin/bun', 'optimize', '123');
+    expect(args).toEqual(['src/cli/index.ts', 'optimize', '123']);
+  });
+
+  test('dev mode: includes extra args', () => {
+    const argv = ['/usr/local/bin/bun', 'src/cli/index.ts', 'list', '-i'];
+    const args = buildSelfArgs(argv, '/usr/local/bin/bun', 'optimize', '123', [
+      '--quality',
+      '85',
+      '--preview',
+    ]);
+    expect(args).toEqual(['src/cli/index.ts', 'optimize', '123', '--quality', '85', '--preview']);
+  });
+
+  test('compiled mode: command is first arg (no script path)', () => {
+    const argv = ['/usr/local/bin/localpress', 'list', '-i'];
+    const args = buildSelfArgs(argv, '/usr/local/bin/localpress', 'optimize', '123');
+    expect(args).toEqual(['optimize', '123']);
+  });
+
+  test('compiled mode: includes extra args', () => {
+    const argv = ['/usr/local/bin/localpress', 'list', '-i'];
+    const args = buildSelfArgs(argv, '/usr/local/bin/localpress', 'remove-bg', '456', [
+      '--model',
+      'birefnet-lite',
+    ]);
+    expect(args).toEqual(['remove-bg', '456', '--model', 'birefnet-lite']);
+  });
+
+  test('compiled mode: works with Homebrew path', () => {
+    const execPath = '/opt/homebrew/Cellar/localpress/1.8.1/bin/localpress';
+    const argv = [execPath, 'list', '-i'];
+    const args = buildSelfArgs(argv, execPath, 'edit', '789');
+    expect(args).toEqual(['edit', '789']);
+  });
+});


### PR DESCRIPTION
## Problem

When using `list -i` and triggering a subcommand (e.g. pressing `o` to optimize, `e` to edit), the error appears:

```
error: Script not found "optimize"
```

## Root Cause

The interactive browser spawns subcommands via `spawnSync(process.argv[0], ...)`. In compiled Bun binaries, `process.argv[0]` can resolve to the `bun` runtime path rather than the `localpress` binary. When Bun receives `bun optimize`, it looks for a `"optimize"` script in package.json — which doesn't exist.

## Fix

- Use `process.execPath` as the binary to spawn in compiled mode (this always points to the actual executable)
- Add a guard to the `isDevMode` check: even if `process.argv[1]` ends in `.ts`, if `process.execPath` contains `localpress`, we're in compiled mode (Bun embeds the source path in compiled binaries)

```typescript
const isDevMode =
  /\.(ts|mts|js|mjs)$/.test(process.argv[1] ?? '') &&
  !process.execPath.includes('localpress');
const selfBin = isDevMode ? process.argv[0] : process.execPath;
```

## Testing

```
bun run typecheck  →  clean
bun run lint       →  clean
bun test test/unit →  92 pass
```
