### PR TITLE
fix: graceful error message when sharp is missing in compiled binary

### DIFF
--- a/src/engine/image/optimize.ts
+++ b/src/engine/image/optimize.ts
@@ -34,7 +34,27 @@ export async function optimizeImage(
   opts: OptimizeOptions = {},
 ): Promise<OptimizeResult> {
   // Lazy-load sharp so the CLI boots even if sharp's platform binary is missing.
-  const { default: sharp } = await import('sharp');
+  // biome-ignore lint/suspicious/noExplicitAny: sharp's type export is complex
+  let sharp: any;
+  try {
+    const mod = await import('sharp');
+    sharp = mod.default;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes('Cannot find package') || msg.includes('MODULE_NOT_FOUND')) {
+      throw new Error(
+        'sharp is not installed. Image processing requires sharp.\n\n' +
+          'Install it with:\n' +
+          '  npm install -g sharp\n' +
+          '  # or, if using Bun:\n' +
+          '  bun install -g sharp\n\n' +
+          'If you installed localpress via Homebrew, run:\n' +
+          '  brew install vips && npm install -g sharp\n\n' +
+          'See: https://sharp.pixelplumbing.com/install',
+      );
+    }
+    throw err;
+  }
 
   // Probe the source image for metadata.
   const metadata = await sharp(sourceBytes).metadata();

--- a/src/engine/rembg/remove-bg.ts
+++ b/src/engine/rembg/remove-bg.ts
@@ -82,7 +82,27 @@ export async function removeBackground(
   const modelPath = await ensureModel(modelName, options.onProgress);
 
   // 2. Lazy-load dependencies.
-  const { default: sharp } = await import('sharp');
+  // biome-ignore lint/suspicious/noExplicitAny: sharp's type export is complex
+  let sharp: any;
+  try {
+    const mod = await import('sharp');
+    sharp = mod.default;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes('Cannot find package') || msg.includes('MODULE_NOT_FOUND')) {
+      throw new Error(
+        'sharp is not installed. Background removal requires sharp for image processing.\n\n' +
+          'Install it with:\n' +
+          '  npm install -g sharp\n' +
+          '  # or, if using Bun:\n' +
+          '  bun install -g sharp\n\n' +
+          'If you installed localpress via Homebrew, run:\n' +
+          '  brew install vips && npm install -g sharp\n\n' +
+          'See: https://sharp.pixelplumbing.com/install',
+      );
+    }
+    throw err;
+  }
   // onnxruntime-node is loaded dynamically — it has native binaries that
   // may not be present at typecheck time or in all environments.
   const ort = (await import('onnxruntime-node')) as import('./onnx-types.ts').OnnxRuntime;


### PR DESCRIPTION
## Problem

When running `optimize` or `remove-bg` from the compiled binary (Homebrew or direct download), users get:

```
ResolveMessage: Cannot find package 'sharp' from '/$bunfs/root/localpress-darwin-arm64'
```

This happens because the build uses `--external sharp` — sharp's native bindings can't be bundled into a single-file binary, so it must be installed separately at runtime.

## Fix

Catches the import error in both `optimizeImage()` and `removeBackground()` and throws a clear, actionable error message:

```
sharp is not installed. Image processing requires sharp.

Install it with:
  npm install -g sharp
  # or, if using Bun:
  bun install -g sharp

If you installed localpress via Homebrew, run:
  brew install vips && npm install -g sharp

See: https://sharp.pixelplumbing.com/install
```

## Scope

This is a **mitigation**, not a full fix. The underlying issue is that the Homebrew formula and binary downloads don't include sharp. A proper fix would be one of:

1. Update the Homebrew formula to install sharp alongside the binary (post-install step)
2. Bundle a WASM-based sharp alternative that doesn't need native bindings
3. Ship a wrapper script that sets `NODE_PATH` to a bundled `node_modules`

This PR gives users an immediate path forward while we figure out the right long-term distribution strategy.

## Files Changed

- `src/engine/image/optimize.ts` — catch sharp import error with install instructions
- `src/engine/rembg/remove-bg.ts` — same treatment

## Testing

```
bun run typecheck  →  clean
bun run lint       →  clean
bun test test/unit →  109 pass
```
