### PR TITLE
feat: bundle @img/sharp-wasm32 as fallback for compiled binaries

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "localpress",
       "dependencies": {
+        "@img/sharp-wasm32": "^0.34.5",
         "@jsquash/avif": "^2.1.1",
         "@jsquash/jpeg": "^1.6.0",
         "@jsquash/oxipng": "^2.3.0",
@@ -83,7 +84,7 @@
 
     "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="],
 
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.33.5", "", { "dependencies": { "@emnapi/runtime": "^1.2.0" }, "cpu": "none" }, "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg=="],
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
 
     "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.33.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ=="],
 
@@ -310,6 +311,8 @@
     "matcher/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "serialize-error/type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
+
+    "sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.33.5", "", { "dependencies": { "@emnapi/runtime": "^1.2.0" }, "cpu": "none" }, "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg=="],
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -46,19 +46,20 @@
     "format": "biome format --write ."
   },
   "dependencies": {
+    "@img/sharp-wasm32": "^0.34.5",
+    "@jsquash/avif": "^2.1.1",
+    "@jsquash/jpeg": "^1.6.0",
+    "@jsquash/oxipng": "^2.3.0",
+    "@jsquash/png": "^3.1.1",
+    "@jsquash/resize": "^2.1.1",
+    "@jsquash/webp": "^1.5.0",
+    "chokidar": "^3.6.0",
     "commander": "^12.1.0",
     "ink": "^5.0.1",
-    "react": "^18.3.1",
-    "sharp": "^0.33.5",
-    "@jsquash/jpeg": "^1.6.0",
-    "@jsquash/png": "^3.1.1",
-    "@jsquash/webp": "^1.5.0",
-    "@jsquash/avif": "^2.1.1",
-    "@jsquash/oxipng": "^2.3.0",
-    "@jsquash/resize": "^2.1.1",
-    "chokidar": "^3.6.0",
     "onnxruntime-node": "^1.22.0",
-    "pino": "^9.5.0"
+    "pino": "^9.5.0",
+    "react": "^18.3.1",
+    "sharp": "^0.33.5"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -341,7 +341,8 @@ async function detectDuplicates(items: MediaItem[]): Promise<AuditFinding[]> {
   // biome-ignore lint/suspicious/noExplicitAny: sharp is lazy-loaded and may not be installed
   let sharp: any;
   try {
-    sharp = (await import('sharp')).default;
+    const { loadSharp } = await import('../../engine/image/sharp-loader.ts');
+    sharp = await loadSharp();
   } catch {
     warn('--duplicates requires sharp to be installed. Skipping duplicate detection.');
     return [];

--- a/src/engine/image/optimize.ts
+++ b/src/engine/image/optimize.ts
@@ -15,6 +15,7 @@
  */
 
 import { isJsquashSupported, jsquashEncode } from './jsquash.ts';
+import { loadSharp } from './sharp-loader.ts';
 import type {
   CompressionMode,
   ImageFormat,
@@ -33,8 +34,8 @@ export async function optimizeImage(
   sourceMimeType: string,
   opts: OptimizeOptions = {},
 ): Promise<OptimizeResult> {
-  // Lazy-load sharp so the CLI boots even if sharp's platform binary is missing.
-  const { default: sharp } = await import('sharp');
+  // Lazy-load sharp (native or WASM fallback) so the CLI boots fast.
+  const sharp = await loadSharp();
 
   // Probe the source image for metadata.
   const metadata = await sharp(sourceBytes).metadata();

--- a/src/engine/image/sharp-loader.ts
+++ b/src/engine/image/sharp-loader.ts
@@ -1,0 +1,55 @@
+/**
+ * Sharp loader with WASM fallback.
+ *
+ * Tries to load native sharp first (fastest, requires platform binary).
+ * Falls back to @img/sharp-wasm32 (bundleable, works in compiled binaries).
+ * Throws a helpful error if neither is available.
+ *
+ * This solves the "Cannot find package 'sharp' from /$bunfs/..." error
+ * that occurs in Bun-compiled binaries where native modules can't be bundled.
+ */
+
+// biome-ignore lint/suspicious/noExplicitAny: sharp's type export varies between native and wasm
+type SharpModule = any;
+
+let cachedSharp: SharpModule | null = null;
+
+/**
+ * Load sharp with automatic fallback to WASM.
+ *
+ * Results are cached — the module resolution only happens once.
+ * Subsequent calls return the cached instance immediately.
+ */
+export async function loadSharp(): Promise<SharpModule> {
+  if (cachedSharp) return cachedSharp;
+
+  // Try 1: Native sharp (fast, requires platform-specific binary).
+  try {
+    const mod = await import('sharp');
+    cachedSharp = mod.default;
+    return cachedSharp;
+  } catch {
+    // Native sharp not available — try WASM fallback.
+  }
+
+  // Try 2: WASM build (slower but works everywhere, bundleable).
+  try {
+    const mod = await import('@img/sharp-wasm32');
+    cachedSharp = mod.default ?? mod;
+    return cachedSharp;
+  } catch {
+    // WASM also not available.
+  }
+
+  // Neither available — throw helpful error.
+  throw new Error(
+    'sharp is not installed. Image processing requires sharp.\n\n' +
+      'Install it with:\n' +
+      '  npm install -g sharp\n' +
+      '  # or, if using Bun:\n' +
+      '  bun install -g sharp\n\n' +
+      'If you installed localpress via Homebrew, run:\n' +
+      '  brew install vips && npm install -g sharp\n\n' +
+      'See: https://sharp.pixelplumbing.com/install',
+  );
+}

--- a/src/engine/rembg/remove-bg.ts
+++ b/src/engine/rembg/remove-bg.ts
@@ -82,7 +82,8 @@ export async function removeBackground(
   const modelPath = await ensureModel(modelName, options.onProgress);
 
   // 2. Lazy-load dependencies.
-  const { default: sharp } = await import('sharp');
+  const { loadSharp } = await import('../image/sharp-loader.ts');
+  const sharp = await loadSharp();
   // onnxruntime-node is loaded dynamically — it has native binaries that
   // may not be present at typecheck time or in all environments.
   const ort = (await import('onnxruntime-node')) as import('./onnx-types.ts').OnnxRuntime;

--- a/src/shims/sharp-wasm32.d.ts
+++ b/src/shims/sharp-wasm32.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Type declaration for @img/sharp-wasm32.
+ *
+ * The WASM build of sharp has the same API as native sharp but doesn't
+ * ship its own type declarations.
+ */
+declare module '@img/sharp-wasm32' {
+  // biome-ignore lint/suspicious/noExplicitAny: WASM module export shape varies
+  const sharp: any;
+  export default sharp;
+  export = sharp;
+}


### PR DESCRIPTION
Supersedes #24

## Problem

Running `optimize`, `convert`, `resize`, or `remove-bg` from the compiled binary fails with:

```
ResolveMessage: Cannot find package 'sharp' from '/$bunfs/root/localpress-darwin-arm64'
```

The build uses `--external sharp` because native `.node` addons can't be bundled into a single-file binary. But this means sharp must be installed separately — which users don't know about.

## Solution

Add `@img/sharp-wasm32` as a bundled fallback. This is the official WASM build of sharp (same API, same version line, Apache-2.0 licensed) that compiles libvips to WebAssembly. Since it's pure WASM, it CAN be bundled into the compiled binary.

### Loading strategy (`src/engine/image/sharp-loader.ts`):

1. **Try native `sharp`** — fastest, uses platform-specific libvips binary
2. **Fall back to `@img/sharp-wasm32`** — slower but works everywhere, bundled into the binary
3. **If both fail** — throw a helpful error with install instructions

Results are cached so module resolution only happens once per process.

### Why this works:

- `sharp` is in the `--external` list → NOT bundled (can't bundle native binaries)
- `@img/sharp-wasm32` is NOT in the `--external` list → IS bundled into the compiled binary
- At runtime: native sharp resolves if the user has it installed (e.g. dev mode), otherwise the bundled WASM version kicks in

### Tradeoff:

WASM sharp is ~2-3x slower than native for heavy operations, but it works out of the box with zero user setup. Users who want maximum performance can install native sharp globally (`npm install -g sharp`).

## Files Changed

- `src/engine/image/sharp-loader.ts` — new cached loader with native→WASM fallback
- `src/engine/image/optimize.ts` — uses `loadSharp()` instead of direct import
- `src/engine/rembg/remove-bg.ts` — same
- `src/cli/commands/audit.ts` — same (duplicate detection)
- `src/shims/sharp-wasm32.d.ts` — type declaration for the WASM package
- `package.json` — added `@img/sharp-wasm32` ^0.34.5 dependency

## Testing

```
bun run typecheck  →  clean
bun run lint       →  clean
bun test test/unit →  109 pass
```

Note: the binary size will increase since the WASM build of libvips is bundled. This is the tradeoff for zero-setup image processing.
