### PR TITLE
fix: preview apply ERR_EMPTY_RESPONSE + O skips terminal form

### DIFF
--- a/src/cli/components/MediaBrowser.tsx
+++ b/src/cli/components/MediaBrowser.tsx
@@ -515,16 +515,10 @@ export function MediaBrowser({
       if (item?.mimeType.startsWith('image/'))
         doExit({ type: 'remove-bg', id: item.id, page, cursor, preview: true });
     } else if (input === 'O') {
+      // Skip the terminal settings form — go straight to browser preview.
       const item = filteredItems[cursor];
       if (item) {
-        setOptimizeQuality('');
-        setOptimizeFormat('keep');
-        setOptimizeKeepOriginal(false);
-        setOptimizeActiveField('quality');
-        setOptimizeMode(true);
-        // Flag that this optimize session should use --preview.
-        // We store it in a ref-like pattern via the state.
-        setOptimizePreview(true);
+        doExit({ type: 'optimize', id: item.id, page, cursor, preview: true });
       }
     } else if (input === 'c') {
       const item = filteredItems[cursor];

--- a/src/engine/preview/server.ts
+++ b/src/engine/preview/server.ts
@@ -171,8 +171,12 @@ export async function startPreviewServer(
         }
         try {
           const result = await options.onApply(state.lastResultBytes);
-          shutdown();
-          resolvePromise({ applied: true, result });
+          // Delay shutdown to ensure the response is fully sent to the browser
+          // before the server closes the TCP connection.
+          setTimeout(() => {
+            shutdown();
+            resolvePromise({ applied: true, result });
+          }, 500);
           return new Response(JSON.stringify(result), {
             headers: { 'Content-Type': 'application/json' },
           });


### PR DESCRIPTION
## Problems

1. **`/api/apply` returns ERR_EMPTY_RESPONSE**: When clicking "Apply & Upload" in the browser preview, the fetch fails because the server shuts down before the HTTP response is fully flushed.

2. **`O` shows terminal settings form before opening browser**: Pressing `O` (optimize with preview) currently shows the same quality/format/keep-original form as `o`, then spawns the preview. Users expect `O` to go straight to the browser where they can adjust everything visually.

## Fixes

### 1. Delayed shutdown on `/api/apply`

The server was calling `shutdown()` → `server.stop(true)` immediately after constructing the response. The `true` flag means "close immediately" — tearing down the TCP connection before the response bytes are fully sent.

Fix: delay shutdown by 500ms after the response is returned, giving the browser time to receive the full response.

### 2. `O` skips terminal form, goes straight to browser

`O` now immediately exits the MediaBrowser with `{ type: 'optimize', preview: true }` — no terminal settings overlay. The browser preview has all the same controls (quality, format, encoder, resize) in a better visual interface.

`o` (lowercase) still shows the terminal settings form for quick non-preview optimization.

## Testing

```
bun run typecheck  →  clean
bun run lint       →  clean
bun test test/unit →  109 pass
```
