### PR TITLE
fix: preview server idleTimeout causes apply to fail after 10s

### DIFF
--- a/src/engine/preview/server.ts
+++ b/src/engine/preview/server.ts
@@ -96,6 +96,9 @@ export async function startPreviewServer(
   state.server = Bun.serve({
     port,
     hostname: '127.0.0.1',
+    // The apply endpoint can take 30+ seconds (SCP upload + wp media regenerate over SSH).
+    // Bun's default idleTimeout is 10s which kills the connection mid-operation.
+    idleTimeout: 120,
     fetch: async (req, server) => {
       const url = new URL(req.url);
 
@@ -170,7 +173,9 @@ export async function startPreviewServer(
           });
         }
         try {
+          info('  Applying optimized image to WordPress...');
           const result = await options.onApply(state.lastResultBytes);
+          info(`  ✓ Applied successfully (${result.message})`);
           // Delay shutdown to ensure the response is fully sent to the browser
           // before the server closes the TCP connection.
           setTimeout(() => {
@@ -182,6 +187,7 @@ export async function startPreviewServer(
           });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
+          warn(`  Apply failed: ${message}`);
           return new Response(JSON.stringify({ error: message }), {
             status: 500,
             headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Problem

Clicking "Apply & Upload to WordPress" in the browser preview fails with:

```
Failed to load resource: net::ERR_EMPTY_RESPONSE
```

Terminal shows:
```
[Bun.serve]: request timed out after 10 seconds. Pass `idleTimeout` to configure.
Browser tab closed. Shutting down preview server.
```

## Root Cause

Bun.serve() has a default `idleTimeout` of 10 seconds. The `/api/apply` endpoint calls `onApply()` which does WP-CLI replace-in-place over SSH:

1. SCP upload the optimized file to the server
2. `mv` it into place
3. `wp media regenerate` to rebuild thumbnails

This easily takes 10-30+ seconds on a remote server. Bun kills the connection at 10s, the browser gets ERR_EMPTY_RESPONSE, and the WebSocket heartbeat detects the tab "closed" (because the connection died).

## Fix

Set `idleTimeout: 120` (2 minutes) on the Bun.serve() options. This gives plenty of time for SSH operations to complete.

Also added `info()`/`warn()` logging to the apply endpoint so you can see progress and failures in the terminal.

## Testing

```
bun run typecheck  →  clean
bun run lint       →  clean
bun test test/unit →  109 pass
```
