### PR TITLE
feat: add `localpress regenerate` command

### DIFF
--- a/src/cli/commands/regenerate.ts
+++ b/src/cli/commands/regenerate.ts
@@ -1,0 +1,141 @@
+/**
+ * `localpress regenerate` — regenerate WordPress thumbnails.
+ *
+ * Calls `wp media regenerate` via WP-CLI for one or more attachments.
+ * Useful after:
+ *   - Bulk optimizing without --regenerate-thumbnails
+ *   - Changing themes (new image sizes registered)
+ *   - Fixing broken/missing thumbnails
+ *
+ * Requires WP-CLI (SSH) — the `regenerate-thumbnails` capability.
+ */
+
+import { cpus } from 'node:os';
+import type { Command } from 'commander';
+import { AdapterResolver } from '../../adapters/resolver.ts';
+import { loadConfig, resolveActiveSite } from '../utils/config.ts';
+import { error, info, printJson, warn } from '../utils/output.ts';
+
+export function registerRegenerateCommand(program: Command): void {
+  program
+    .command('regenerate')
+    .description('Regenerate WordPress thumbnails for attachments (requires WP-CLI)')
+    .argument('[ids...]', 'attachment IDs to regenerate')
+    .option('--all', 'regenerate thumbnails for all attachments')
+    .action(async (idStrs: string[], options) => {
+      const parentOpts = program.opts();
+      const config = await loadConfig();
+      const site = resolveActiveSite(config, parentOpts.site);
+      const resolver = new AdapterResolver(site);
+
+      const hasExplicitIds = idStrs.length > 0;
+      const isBulk = Boolean(options.all);
+
+      if (!hasExplicitIds && !isBulk) {
+        error(
+          'Specify attachment IDs, or use --all for bulk regeneration.\n' +
+            'Example: localpress regenerate 123 124 125\n' +
+            'Example: localpress regenerate --all --apply',
+        );
+        process.exit(2);
+      }
+
+      // Check capability.
+      const adapter = resolver.tryResolve('regenerate-thumbnails');
+      if (!adapter) {
+        error(
+          'Thumbnail regeneration requires WP-CLI over SSH.\n' +
+            'Configure SSH in your site config to unlock this capability.\n' +
+            'Run `localpress doctor` to see your current capabilities.',
+        );
+        process.exit(6);
+      }
+
+      // Resolve IDs.
+      let ids: number[];
+
+      if (hasExplicitIds) {
+        ids = idStrs.map((s) => Number.parseInt(s, 10)).filter((n) => !Number.isNaN(n));
+        if (ids.length === 0) {
+          error('No valid attachment IDs provided.');
+          process.exit(2);
+        }
+      } else {
+        // --all: list all attachments.
+        if (!parentOpts.apply && !parentOpts.dryRun) {
+          // Default to dry-run for bulk.
+          info('Dry-run mode (pass --apply to execute):\n');
+        }
+
+        const listAdapter = resolver.resolve('list');
+        const allItems = await listAdapter.listMedia({ perPage: 100, page: 1 });
+        ids = allItems.map((item) => item.id);
+
+        if (ids.length === 0) {
+          info('No attachments found.');
+          return;
+        }
+
+        if (!parentOpts.apply) {
+          info(`Would regenerate thumbnails for ${ids.length} attachment(s).`);
+          if (parentOpts.json) {
+            printJson({ dryRun: true, count: ids.length, ids });
+          }
+          return;
+        }
+      }
+
+      // Execute regeneration.
+      const concurrency = parentOpts.concurrency ?? Math.max(1, cpus().length - 1);
+      const results: Array<{ id: number; status: 'success' | 'failure'; error?: string }> = [];
+      let succeeded = 0;
+      let failed = 0;
+
+      if (!parentOpts.json) {
+        info(`Regenerating thumbnails for ${ids.length} attachment(s)...\n`);
+      }
+
+      // Process in batches for concurrency.
+      for (let i = 0; i < ids.length; i += concurrency) {
+        const batch = ids.slice(i, i + concurrency);
+        const batchResults = await Promise.allSettled(
+          batch.map(async (id) => {
+            await adapter.regenerateThumbnails(id);
+            return id;
+          }),
+        );
+
+        for (let j = 0; j < batchResults.length; j++) {
+          const result = batchResults[j];
+          const id = batch[j];
+
+          if (result.status === 'fulfilled') {
+            succeeded++;
+            results.push({ id, status: 'success' });
+            if (!parentOpts.json) {
+              info(`  ✓ #${id} regenerated`);
+            }
+          } else {
+            failed++;
+            const errMsg =
+              result.reason instanceof Error ? result.reason.message : String(result.reason);
+            results.push({ id, status: 'failure', error: errMsg });
+            if (!parentOpts.json) {
+              warn(`  ✗ #${id} failed: ${errMsg}`);
+            }
+          }
+        }
+      }
+
+      // Summary.
+      if (parentOpts.json) {
+        printJson({ succeeded, failed, total: ids.length, results });
+      } else {
+        info(`\nDone: ${succeeded} succeeded, ${failed} failed (${ids.length} total).`);
+      }
+
+      if (failed > 0) {
+        process.exit(1);
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,6 +22,7 @@ import { registerOptimizeCommand } from './commands/optimize.ts';
 import { registerPullCommand } from './commands/pull.ts';
 import { registerPushCommand } from './commands/push.ts';
 import { registerReferencesCommand } from './commands/references.ts';
+import { registerRegenerateCommand } from './commands/regenerate.ts';
 import { registerRemoveBgCommand } from './commands/remove-bg.ts';
 import { registerResizeCommand } from './commands/resize.ts';
 import { registerShowCommand } from './commands/show.ts';
@@ -77,6 +78,7 @@ registerEditCommand(program);
 registerPullCommand(program);
 registerPushCommand(program);
 registerReferencesCommand(program);
+registerRegenerateCommand(program);
 registerUpdateCommand(program);
 registerCompletionsCommand(program);
 


### PR DESCRIPTION
Closes #29

## Summary

Adds a `localpress regenerate` command for rebuilding WordPress thumbnails via WP-CLI.

## Usage

```bash
# Regenerate specific attachments
localpress regenerate 123 124 125

# Dry-run: see what would be regenerated
localpress regenerate --all

# Execute bulk regeneration
localpress regenerate --all --apply

# JSON output
localpress --json regenerate 123
```

## Context

Since PR #28 made thumbnail regeneration opt-in on replace-in-place, users need a dedicated command to regenerate thumbnails when they want to:
- After bulk-optimizing without `--regenerate-thumbnails`
- After a theme change that registers new image sizes
- To fix broken/missing thumbnails

## Features

- Requires WP-CLI (`regenerate-thumbnails` capability)
- Supports `--concurrency` for parallel regeneration (default: CPU count - 1)
- Bulk mode (`--all`) is dry-run by default, requires `--apply`
- Per-item success/failure reporting
- Full `--json` output

## Testing

```
bun run dev -- regenerate --help  →  shows usage
bun run typecheck                 →  clean
bun run lint                      →  clean
bun test test/unit                →  109 pass
```
