### PR TITLE
feat: sharp path discovery + auto-install on first use

### DIFF
--- a/Formula/localpress.rb
+++ b/Formula/localpress.rb
@@ -39,8 +39,27 @@ class Localpress < Formula
     end
   end
 
+  depends_on "vips"
+
   def install
     bin.install Dir["localpress*"].first => "localpress"
+
+    # Install sharp globally so the compiled binary can find it at runtime.
+    # sharp is a native module that can't be bundled into single-file binaries.
+    system "npm", "install", "-g", "sharp"
+  end
+
+  def caveats
+    <<~EOS
+      localpress requires sharp for image processing.
+      It was installed globally via npm during formula installation.
+
+      If you encounter issues, reinstall with:
+        npm install -g sharp
+
+      Verify with:
+        localpress doctor
+    EOS
   end
 
   test do

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
     "": {
       "name": "localpress",
       "dependencies": {
-        "@img/sharp-wasm32": "^0.34.5",
         "@jsquash/avif": "^2.1.1",
         "@jsquash/jpeg": "^1.6.0",
         "@jsquash/oxipng": "^2.3.0",
@@ -84,7 +83,7 @@
 
     "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="],
 
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.33.5", "", { "dependencies": { "@emnapi/runtime": "^1.2.0" }, "cpu": "none" }, "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg=="],
 
     "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.33.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ=="],
 
@@ -311,8 +310,6 @@
     "matcher/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "serialize-error/type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
-
-    "sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.33.5", "", { "dependencies": { "@emnapi/runtime": "^1.2.0" }, "cpu": "none" }, "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg=="],
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "format": "biome format --write ."
   },
   "dependencies": {
-    "@img/sharp-wasm32": "^0.34.5",
     "@jsquash/avif": "^2.1.1",
     "@jsquash/jpeg": "^1.6.0",
     "@jsquash/oxipng": "^2.3.0",

--- a/src/cli/commands/convert.ts
+++ b/src/cli/commands/convert.ts
@@ -44,6 +44,18 @@ export function registerConvertCommand(program: Command): void {
       const resolver = new AdapterResolver(site);
       const getAdapter = resolver.resolve('get');
 
+      // Preload sharp (with auto-install prompt if missing).
+      try {
+        const { loadSharpWithPrompt } = await import('../../engine/image/sharp-loader.ts');
+        await loadSharpWithPrompt({
+          autoYes: Boolean(parentOpts.yes),
+          noPrompt: Boolean(parentOpts.json) || Boolean(parentOpts.quiet),
+        });
+      } catch (err) {
+        error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+
       const db = SiteDb.init(getSiteDbPath(site.name));
       db.ensureSite(site.name, site.url);
 

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -152,6 +152,21 @@ export function registerDoctorCommand(program: Command): void {
           });
         }
 
+        // -- Sharp availability check -----------------------------------------
+        let sharpAvailable = false;
+        try {
+          const { loadSharp } = await import('../../engine/image/sharp-loader.ts');
+          await loadSharp();
+          sharpAvailable = true;
+        } catch {
+          issues.push({
+            severity: 'error',
+            message:
+              'sharp is not installed — optimize, convert, resize, and remove-bg will not work',
+            fix: 'Run `bun install -g sharp` or `npm install -g sharp` (macOS: `brew install vips` first)',
+          });
+        }
+
         // -- Plugin detection --------------------------------------------------
         let plugins: PluginStatus[] = [];
         if (options.plugins || options.fix) {
@@ -208,6 +223,7 @@ export function registerDoctorCommand(program: Command): void {
             site: name,
             url: site.url,
             connectionOk,
+            sharpAvailable,
             adapters: availability,
             capabilities: report,
             issues,
@@ -218,6 +234,7 @@ export function registerDoctorCommand(program: Command): void {
           info(`  ${connectionOk ? '✓' : '✗'} REST API connection`);
           info(`  ${availability.wpCli ? '✓' : '✗'} WP-CLI (SSH)`);
           info(`  ${availability.mcp ? '✓' : '✗'} MCP`);
+          info(`  ${sharpAvailable ? '✓' : '✗'} sharp (image processing)`);
           info('');
           info('  Capabilities:');
           for (const cap of report) {

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -159,12 +159,40 @@ export function registerDoctorCommand(program: Command): void {
           await loadSharp();
           sharpAvailable = true;
         } catch {
-          issues.push({
-            severity: 'error',
-            message:
-              'sharp is not installed — optimize, convert, resize, and remove-bg will not work',
-            fix: 'Run `bun install -g sharp` or `npm install -g sharp` (macOS: `brew install vips` first)',
-          });
+          // If --fix is passed, try to auto-install.
+          if (options.fix) {
+            info('sharp is not installed. Installing now...');
+            const { installSharpGlobally, loadSharp } = await import(
+              '../../engine/image/sharp-loader.ts'
+            );
+            const ok = await installSharpGlobally();
+            if (ok) {
+              try {
+                await loadSharp();
+                sharpAvailable = true;
+                info('  ✓ sharp installed successfully');
+              } catch {
+                issues.push({
+                  severity: 'error',
+                  message:
+                    'sharp installation completed but module still not found. Try restarting your shell.',
+                });
+              }
+            } else {
+              issues.push({
+                severity: 'error',
+                message: 'Auto-install failed. Neither bun nor npm is available.',
+                fix: 'Install bun or npm, then run `localpress doctor --fix` again',
+              });
+            }
+          } else {
+            issues.push({
+              severity: 'error',
+              message:
+                'sharp is not installed — optimize, convert, resize, and remove-bg will not work',
+              fix: 'Run `localpress doctor --fix` to auto-install, or manually: `bun install -g sharp`',
+            });
+          }
         }
 
         // -- Plugin detection --------------------------------------------------

--- a/src/cli/commands/optimize.ts
+++ b/src/cli/commands/optimize.ts
@@ -92,6 +92,18 @@ export function registerOptimizeCommand(program: Command): void {
         process.exit(2);
       }
 
+      // Preload sharp (with auto-install prompt if missing).
+      try {
+        const { loadSharpWithPrompt } = await import('../../engine/image/sharp-loader.ts');
+        await loadSharpWithPrompt({
+          autoYes: Boolean(parentOpts.yes),
+          noPrompt: Boolean(parentOpts.json) || Boolean(parentOpts.quiet),
+        });
+      } catch (err) {
+        error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+
       // --preview: open a browser-based preview for a single attachment.
       if (options.preview) {
         if (!hasExplicitIds || idStrs.length !== 1) {

--- a/src/cli/commands/remove-bg.ts
+++ b/src/cli/commands/remove-bg.ts
@@ -71,6 +71,21 @@ export function registerRemoveBgCommand(program: Command): void {
         return;
       }
 
+      // Preload sharp (with auto-install prompt if missing).
+      // Skip for --rembg mode since that uses system Python, not sharp.
+      if (!options.rembg) {
+        try {
+          const { loadSharpWithPrompt } = await import('../../engine/image/sharp-loader.ts');
+          await loadSharpWithPrompt({
+            autoYes: Boolean(parentOpts.yes),
+            noPrompt: Boolean(parentOpts.json) || Boolean(parentOpts.quiet),
+          });
+        } catch (err) {
+          error(err instanceof Error ? err.message : String(err));
+          process.exit(1);
+        }
+      }
+
       // --preview: open a browser-based preview for a single attachment.
       if (options.preview) {
         const ids = idStrs.map((s) => Number.parseInt(s, 10));

--- a/src/cli/commands/resize.ts
+++ b/src/cli/commands/resize.ts
@@ -41,6 +41,18 @@ export function registerResizeCommand(program: Command): void {
       const resolver = new AdapterResolver(site);
       const getAdapter = resolver.resolve('get');
 
+      // Preload sharp (with auto-install prompt if missing).
+      try {
+        const { loadSharpWithPrompt } = await import('../../engine/image/sharp-loader.ts');
+        await loadSharpWithPrompt({
+          autoYes: Boolean(parentOpts.yes),
+          noPrompt: Boolean(parentOpts.json) || Boolean(parentOpts.quiet),
+        });
+      } catch (err) {
+        error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+
       const db = SiteDb.init(getSiteDbPath(site.name));
       db.ensureSite(site.name, site.url);
 

--- a/src/engine/image/sharp-loader.ts
+++ b/src/engine/image/sharp-loader.ts
@@ -1,55 +1,47 @@
 /**
- * Sharp loader with WASM fallback.
+ * Sharp loader with graceful error handling.
  *
- * Tries to load native sharp first (fastest, requires platform binary).
- * Falls back to @img/sharp-wasm32 (bundleable, works in compiled binaries).
- * Throws a helpful error if neither is available.
+ * Sharp is a native module (libvips bindings) that can't be bundled into
+ * Bun's compiled single-file binaries. It must be installed separately
+ * on the user's machine.
  *
- * This solves the "Cannot find package 'sharp' from /$bunfs/..." error
- * that occurs in Bun-compiled binaries where native modules can't be bundled.
+ * This loader:
+ *   1. Tries to import sharp (works in dev mode and when globally installed)
+ *   2. Throws a clear, actionable error if sharp isn't found
+ *
+ * The result is cached — module resolution only happens once per process.
  */
 
-// biome-ignore lint/suspicious/noExplicitAny: sharp's type export varies between native and wasm
+// biome-ignore lint/suspicious/noExplicitAny: sharp's type export varies by version
 type SharpModule = any;
 
 let cachedSharp: SharpModule | null = null;
 
 /**
- * Load sharp with automatic fallback to WASM.
+ * Load sharp with a helpful error message if it's not installed.
  *
- * Results are cached — the module resolution only happens once.
- * Subsequent calls return the cached instance immediately.
+ * Results are cached — subsequent calls return immediately.
  */
 export async function loadSharp(): Promise<SharpModule> {
   if (cachedSharp) return cachedSharp;
 
-  // Try 1: Native sharp (fast, requires platform-specific binary).
   try {
     const mod = await import('sharp');
     cachedSharp = mod.default;
     return cachedSharp;
   } catch {
-    // Native sharp not available — try WASM fallback.
+    // sharp not available.
   }
 
-  // Try 2: WASM build (slower but works everywhere, bundleable).
-  try {
-    const mod = await import('@img/sharp-wasm32');
-    cachedSharp = mod.default ?? mod;
-    return cachedSharp;
-  } catch {
-    // WASM also not available.
-  }
-
-  // Neither available — throw helpful error.
   throw new Error(
-    'sharp is not installed. Image processing requires sharp.\n\n' +
-      'Install it with:\n' +
-      '  npm install -g sharp\n' +
-      '  # or, if using Bun:\n' +
+    'sharp is not installed. Image processing requires sharp (libvips).\n\n' +
+      'Quick fix:\n' +
       '  bun install -g sharp\n\n' +
-      'If you installed localpress via Homebrew, run:\n' +
-      '  brew install vips && npm install -g sharp\n\n' +
+      'Or with npm:\n' +
+      '  npm install -g sharp\n\n' +
+      'On macOS with Homebrew:\n' +
+      '  brew install vips && bun install -g sharp\n\n' +
+      'After installing, run `localpress doctor` to verify.\n' +
       'See: https://sharp.pixelplumbing.com/install',
   );
 }

--- a/src/engine/image/sharp-loader.ts
+++ b/src/engine/image/sharp-loader.ts
@@ -1,16 +1,19 @@
 /**
- * Sharp loader with graceful error handling.
+ * Sharp loader with smart path discovery and auto-install.
  *
  * Sharp is a native module (libvips bindings) that can't be bundled into
- * Bun's compiled single-file binaries. It must be installed separately
- * on the user's machine.
+ * Bun's compiled single-file binaries. This loader finds sharp in three ways:
  *
- * This loader:
- *   1. Tries to import sharp (works in dev mode and when globally installed)
- *   2. Throws a clear, actionable error if sharp isn't found
+ *   1. Standard module resolution (works in dev mode / local node_modules)
+ *   2. Well-known global paths (Bun, npm, Homebrew, yarn globals)
+ *   3. Auto-install prompt (offers to run `bun install -g sharp` on first use)
  *
- * The result is cached — module resolution only happens once per process.
+ * Results are cached — the module resolution only happens once per process.
  */
+
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 
 // biome-ignore lint/suspicious/noExplicitAny: sharp's type export varies by version
 type SharpModule = any;
@@ -18,30 +21,219 @@ type SharpModule = any;
 let cachedSharp: SharpModule | null = null;
 
 /**
- * Load sharp with a helpful error message if it's not installed.
- *
- * Results are cached — subsequent calls return immediately.
+ * Well-known global paths where sharp might be installed.
+ * Ordered by likelihood of containing sharp.
+ */
+function globalNodeModulesPaths(): string[] {
+  const home = homedir();
+  return [
+    // Bun globals (most likely for our users)
+    join(home, '.bun', 'install', 'global', 'node_modules'),
+    // npm globals (Homebrew and system npm)
+    '/opt/homebrew/lib/node_modules',
+    '/usr/local/lib/node_modules',
+    join(home, '.npm-global', 'lib', 'node_modules'),
+    // Yarn globals
+    join(home, '.config', 'yarn', 'global', 'node_modules'),
+    // Windows paths
+    join(process.env.APPDATA ?? '', 'npm', 'node_modules'),
+    join(home, 'AppData', 'Roaming', 'npm', 'node_modules'),
+  ].filter((p) => p && p !== '/node_modules');
+}
+
+/**
+ * Try to find sharp in one of the well-known global paths.
+ * Returns the absolute path to the sharp package directory, or null.
+ */
+function findSharpInGlobals(): string | null {
+  for (const basePath of globalNodeModulesPaths()) {
+    const sharpPath = join(basePath, 'sharp');
+    if (existsSync(join(sharpPath, 'package.json'))) {
+      return sharpPath;
+    }
+  }
+  return null;
+}
+
+/**
+ * Load sharp, trying standard resolution first, then well-known global paths.
+ * Does NOT prompt for install — use loadSharpWithPrompt() for that.
  */
 export async function loadSharp(): Promise<SharpModule> {
   if (cachedSharp) return cachedSharp;
 
+  // Try 1: Standard module resolution (dev mode, local node_modules).
   try {
     const mod = await import('sharp');
     cachedSharp = mod.default;
     return cachedSharp;
   } catch {
-    // sharp not available.
+    // Not in local node_modules — try global paths.
   }
 
-  throw new Error(
-    'sharp is not installed. Image processing requires sharp (libvips).\n\n' +
-      'Quick fix:\n' +
-      '  bun install -g sharp\n\n' +
-      'Or with npm:\n' +
-      '  npm install -g sharp\n\n' +
-      'On macOS with Homebrew:\n' +
-      '  brew install vips && bun install -g sharp\n\n' +
-      'After installing, run `localpress doctor` to verify.\n' +
-      'See: https://sharp.pixelplumbing.com/install',
-  );
+  // Try 2: Well-known global paths.
+  const globalPath = findSharpInGlobals();
+  if (globalPath) {
+    try {
+      const mod = await import(globalPath);
+      cachedSharp = mod.default;
+      return cachedSharp;
+    } catch {
+      // Path exists but import failed — fall through to error.
+    }
+  }
+
+  throw new SharpNotInstalledError();
+}
+
+/**
+ * Check if sharp is available without throwing.
+ */
+export async function isSharpAvailable(): Promise<boolean> {
+  try {
+    await loadSharp();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Custom error class that commands can detect and offer auto-install.
+ */
+export class SharpNotInstalledError extends Error {
+  constructor() {
+    super(
+      'sharp is not installed. Image processing requires sharp (libvips).\n\n' +
+        'Quick fix:\n' +
+        '  bun install -g sharp\n\n' +
+        'Or with npm:\n' +
+        '  npm install -g sharp\n\n' +
+        'On macOS with Homebrew:\n' +
+        '  brew install vips && bun install -g sharp\n\n' +
+        'Or run `localpress doctor --fix` to install automatically.\n' +
+        'See: https://sharp.pixelplumbing.com/install',
+    );
+    this.name = 'SharpNotInstalledError';
+  }
+}
+
+/**
+ * Install sharp globally via bun or npm.
+ * Returns true on success, false on failure.
+ */
+export async function installSharpGlobally(): Promise<boolean> {
+  const { spawn } = await import('node:child_process');
+
+  // Prefer bun if available, fall back to npm.
+  const installer = await detectPackageManager();
+  if (!installer) return false;
+
+  return new Promise((resolve) => {
+    const args = installer === 'bun' ? ['install', '-g', 'sharp'] : ['install', '-g', 'sharp'];
+
+    const proc = spawn(installer, args, { stdio: 'inherit' });
+    proc.on('error', () => resolve(false));
+    proc.on('close', (code) => {
+      if (code === 0) {
+        // Invalidate cache so next loadSharp() re-discovers it.
+        cachedSharp = null;
+      }
+      resolve(code === 0);
+    });
+  });
+}
+
+async function detectPackageManager(): Promise<'bun' | 'npm' | null> {
+  const { spawnSync } = await import('node:child_process');
+
+  // Check bun first (our preferred runtime).
+  try {
+    const result = spawnSync('bun', ['--version'], { stdio: 'ignore' });
+    if (result.status === 0) return 'bun';
+  } catch {
+    // Not installed.
+  }
+
+  // Fall back to npm.
+  try {
+    const result = spawnSync('npm', ['--version'], { stdio: 'ignore' });
+    if (result.status === 0) return 'npm';
+  } catch {
+    // Not installed.
+  }
+
+  return null;
+}
+
+/**
+ * Load sharp, and if not installed, prompt the user to auto-install it.
+ * Respects --yes and --quiet global flags.
+ *
+ * Returns the loaded sharp module, or throws if installation was declined/failed.
+ */
+export async function loadSharpWithPrompt(opts: {
+  /** Skip the prompt and auto-install (e.g. from --yes flag). */
+  autoYes?: boolean;
+  /** Suppress prompts entirely — just throw if not found (e.g. from --json or --quiet). */
+  noPrompt?: boolean;
+}): Promise<SharpModule> {
+  try {
+    return await loadSharp();
+  } catch (err) {
+    if (!(err instanceof SharpNotInstalledError)) throw err;
+
+    if (opts.noPrompt) throw err;
+
+    // Prompt (unless autoYes).
+    let shouldInstall = opts.autoYes ?? false;
+    if (!shouldInstall) {
+      shouldInstall = await promptYesNo(
+        '\nsharp is not installed. Image processing requires it.\nInstall now? [y/N]',
+      );
+    }
+
+    if (!shouldInstall) {
+      throw err;
+    }
+
+    process.stdout.write('\nInstalling sharp (this may take a minute)...\n\n');
+    const success = await installSharpGlobally();
+
+    if (!success) {
+      throw new Error(
+        'Failed to install sharp automatically.\n' +
+          'Please install manually: bun install -g sharp',
+      );
+    }
+
+    process.stdout.write('\nSharp installed. Retrying operation...\n\n');
+    return await loadSharp();
+  }
+}
+
+/**
+ * Minimal y/N prompt using raw stdin.
+ */
+async function promptYesNo(message: string): Promise<boolean> {
+  process.stdout.write(`${message} `);
+
+  return new Promise((resolve) => {
+    const onData = (data: Buffer) => {
+      const input = data.toString().trim().toLowerCase();
+      process.stdin.removeListener('data', onData);
+      process.stdin.pause();
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(false);
+      }
+      process.stdout.write('\n');
+      resolve(input === 'y' || input === 'yes');
+    };
+
+    process.stdin.resume();
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(true);
+    }
+    process.stdin.once('data', onData);
+  });
 }

--- a/test/unit/sharp-loader.test.ts
+++ b/test/unit/sharp-loader.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Unit tests for the sharp loader module.
+ *
+ * Tests the cached loading behavior and the SharpNotInstalledError class.
+ * Path discovery and auto-install are integration concerns (they touch real
+ * filesystem and spawn subprocesses) so they're tested indirectly via behavior.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { SharpNotInstalledError, isSharpAvailable } from '../../src/engine/image/sharp-loader.ts';
+
+describe('SharpNotInstalledError', () => {
+  test('is thrown when sharp cannot be loaded', () => {
+    const err = new SharpNotInstalledError();
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('SharpNotInstalledError');
+  });
+
+  test('message includes actionable install instructions', () => {
+    const err = new SharpNotInstalledError();
+    expect(err.message).toContain('bun install -g sharp');
+    expect(err.message).toContain('npm install -g sharp');
+    expect(err.message).toContain('localpress doctor');
+  });
+});
+
+describe('isSharpAvailable', () => {
+  test('returns a boolean', async () => {
+    const result = await isSharpAvailable();
+    expect(typeof result).toBe('boolean');
+  });
+
+  test('returns true in dev mode (sharp is in node_modules)', async () => {
+    // In the test environment, sharp IS installed (it's a direct dependency).
+    // This verifies the happy path.
+    const result = await isSharpAvailable();
+    expect(result).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

v1.9.0 shows "sharp is not installed" error on compiled binaries. The `@img/sharp-wasm32` fallback from PR #25 never worked because Bun skips platform-mismatched optional deps and can't bundle `.wasm` files into compiled binaries.

## Solution: Make sharp installation nearly invisible

### 1. Smart path discovery

The sharp-loader now checks well-known global paths when standard module resolution fails:

- `~/.bun/install/global/node_modules` (Bun global)
- `/opt/homebrew/lib/node_modules` (Homebrew npm)
- `/usr/local/lib/node_modules` (system npm)
- `~/.npm-global/lib/node_modules` (user-prefix npm)
- `~/.config/yarn/global/node_modules` (Yarn global)
- Windows `%APPDATA%\npm\node_modules`

If sharp is installed globally anywhere, it's found automatically — no user action needed.

### 2. Auto-install prompt

When sharp truly isn't found, commands now offer to install it:

```
sharp is not installed. Image processing requires it.
Install now? [y/N]
```

- Respects `--yes` for unattended installs
- Skips prompt in `--json` / `--quiet` mode (throws cleanly instead)
- Prefers `bun install -g sharp`, falls back to `npm install -g sharp`

Applied to: `optimize`, `convert`, `resize`, `remove-bg`

### 3. `localpress doctor --fix` auto-installs sharp

Running `doctor --fix` now installs sharp automatically if missing, alongside the other remediation it does.

### 4. Homebrew formula installs sharp

```ruby
depends_on "vips"

def install
  bin.install Dir["localpress*"].first => "localpress"
  system "npm", "install", "-g", "sharp"
end
```

### 5. `localpress doctor` reports status

```
Site: production (https://example.com)
  ✓ REST API connection
  ✓ WP-CLI (SSH)
  ✓ sharp (image processing)
```

## Summary of Install Paths

| Method | Sharp handling |
|--------|--------------|
| Homebrew | Installed automatically via formula |
| Binary download → first `optimize` call | Prompt: "Install now? [y/N]" |
| `localpress doctor --fix` | Auto-installs silently |
| Manual | `bun install -g sharp` (we find it) |
| From source (`bun run dev`) | Already in node_modules |

## Removed

- `@img/sharp-wasm32` dependency (dead code, never actually installed)
- `src/shims/sharp-wasm32.d.ts` type declaration

## Testing

```
bun run typecheck  →  clean
bun run lint       →  clean
bun test test/unit →  113 pass (4 new tests for sharp-loader)
```
