### PR TITLE
feat: add `watch` command — continuous directory sync to WordPress

### DIFF
--- a/src/cli/commands/completions.ts
+++ b/src/cli/commands/completions.ts
@@ -67,6 +67,7 @@ const COMMANDS = [
   'push',
   'references',
   'update',
+  'watch',
   'completions',
   'help',
 ];
@@ -169,6 +170,9 @@ _localpress() {
     completions)
       COMPREPLY=( $(compgen -W "bash zsh fish" -- "\${cur}") )
       ;;
+    watch)
+      COMPREPLY=( $(compgen -W "--optimize --quality --to --max-width --max-height --delete --debounce --help" -- "\${cur}") )
+      ;;
     *)
       COMPREPLY=( $(compgen -W "\${global_opts}" -- "\${cur}") )
       ;;
@@ -220,6 +224,7 @@ _localpress() {
     'push:Upload a local file to the media library'
     'references:Show where an attachment is used'
     'update:Check for updates and self-update'
+    'watch:Watch a directory and auto-push images to WordPress'
     'completions:Generate shell completion scripts'
     'help:Display help for a command'
   )
@@ -379,6 +384,18 @@ _localpress() {
         '--check[Just check without installing]' \\
         '(-h --help)'{-h,--help}'[Display help]'
       ;;
+    watch)
+      _arguments -s \\
+        '--optimize[Run optimization pipeline before uploading]' \\
+        '--quality[Target quality (1-100)]:quality:' \\
+        '--to[Convert to format before uploading]:format:(webp avif jpeg png)' \\
+        '--max-width[Maximum width]:pixels:' \\
+        '--max-height[Maximum height]:pixels:' \\
+        '--delete[Delete from WordPress when local file is removed]' \\
+        '--debounce[Debounce interval in ms]:ms:' \\
+        '(-h --help)'{-h,--help}'[Display help]' \\
+        ':directory:_directories'
+      ;;
     completions)
       _arguments -s \\
         ':shell:(bash zsh fish)' \\
@@ -438,6 +455,7 @@ function generateFish(): string {
     ...fishCommand('references', 'Show where an attachment is used'),
     ...fishCommand('update', 'Check for updates and self-update'),
     ...fishCommand('completions', 'Generate shell completion scripts'),
+    ...fishCommand('watch', 'Watch a directory and auto-push images to WordPress'),
     ...fishCommand('help', 'Display help for a command'),
     '',
     '# Subcommand options',
@@ -524,6 +542,14 @@ function generateFish(): string {
     ...fishSubOpt('references', '--update-to', 'Rewrite references to new ID', '-r'),
     '',
     ...fishSubOpt('update', '--check', 'Just check without installing'),
+    '',
+    ...fishSubOpt('watch', '--optimize', 'Run optimization pipeline before uploading'),
+    ...fishSubOpt('watch', '--quality', 'Target quality (1-100)', '-r'),
+    ...fishSubOpt('watch', '--to', 'Convert to format', '-r -a "webp avif jpeg png"'),
+    ...fishSubOpt('watch', '--max-width', 'Maximum width', '-r'),
+    ...fishSubOpt('watch', '--max-height', 'Maximum height', '-r'),
+    ...fishSubOpt('watch', '--delete', 'Delete from WordPress when local file is removed'),
+    ...fishSubOpt('watch', '--debounce', 'Debounce interval in ms', '-r'),
     '',
     '# completions subcommand',
     'complete -c localpress -n "__fish_seen_subcommand_from completions" -a "bash zsh fish" -d "Shell type"',

--- a/src/cli/commands/watch.ts
+++ b/src/cli/commands/watch.ts
@@ -1,0 +1,359 @@
+/**
+ * `localpress watch <directory>` — continuously watch a local directory for
+ * new or changed image files and automatically push them to WordPress.
+ *
+ * Behavior:
+ *   - New files → `push` to WordPress as new attachments
+ *   - Changed files → `push --replace <id>` if we can map the file to an
+ *     existing attachment (via SQLite watch_mappings table)
+ *   - Deleted files → log a warning (don't delete from WP without --delete flag)
+ *   - --optimize flag to run the optimization pipeline before uploading
+ *   - --to <format> to convert on upload
+ *   - Ctrl+C to stop gracefully
+ *
+ * File→attachment mappings are persisted in the site's SQLite database so
+ * re-running watch after a restart picks up where it left off.
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, statSync } from 'node:fs';
+import { basename, relative, resolve } from 'node:path';
+import { watch } from 'chokidar';
+import type { Command } from 'commander';
+import { AdapterResolver } from '../../adapters/resolver.ts';
+import type { CapabilityUnavailableError } from '../../adapters/types.ts';
+import { optimizeImage } from '../../engine/image/optimize.ts';
+import type { ImageFormat } from '../../engine/image/types.ts';
+import { SiteDb } from '../../engine/state/db.ts';
+import { getSiteDbPath, loadConfig, resolveActiveSite } from '../utils/config.ts';
+import { error, info, printJson, warn } from '../utils/output.ts';
+
+/** Image extensions we watch for. */
+const IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.webp', '.avif', '.gif', '.svg']);
+
+/** Debounce interval for file changes (ms). */
+const DEBOUNCE_MS = 800;
+
+function isImageFile(filePath: string): boolean {
+  const ext = filePath.slice(filePath.lastIndexOf('.')).toLowerCase();
+  return IMAGE_EXTENSIONS.has(ext);
+}
+
+function fileHash(buffer: Buffer): string {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+function mimeFromPath(filePath: string): string {
+  const ext = filePath.slice(filePath.lastIndexOf('.')).toLowerCase();
+  switch (ext) {
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.png':
+      return 'image/png';
+    case '.webp':
+      return 'image/webp';
+    case '.avif':
+      return 'image/avif';
+    case '.gif':
+      return 'image/gif';
+    case '.svg':
+      return 'image/svg+xml';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+export function registerWatchCommand(program: Command): void {
+  program
+    .command('watch <directory>')
+    .description('Watch a local directory and auto-push new/changed images to WordPress')
+    .option('--optimize', 'run the optimization pipeline before uploading')
+    .option('--quality <n>', 'optimization quality (1-100)', (v) => Number.parseInt(v, 10))
+    .option('--to <format>', 'convert to format before uploading (webp, avif, jpeg, png)')
+    .option('--max-width <n>', 'max width in pixels', (v) => Number.parseInt(v, 10))
+    .option('--max-height <n>', 'max height in pixels', (v) => Number.parseInt(v, 10))
+    .option('--delete', 'delete from WordPress when local file is removed')
+    .option('--debounce <ms>', 'debounce interval in ms (default: 800)', (v) =>
+      Number.parseInt(v, 10),
+    )
+    .action(async (directory: string, options) => {
+      const parentOpts = program.opts();
+      const config = await loadConfig();
+      const site = resolveActiveSite(config, parentOpts.site);
+      const resolver = new AdapterResolver(site);
+
+      // Resolve and validate the watch directory.
+      const watchDir = resolve(directory);
+      if (!existsSync(watchDir) || !statSync(watchDir).isDirectory()) {
+        error(`Not a directory: ${watchDir}`);
+        process.exit(2);
+      }
+
+      // Open the site database for file→attachment mapping persistence.
+      const dbPath = getSiteDbPath(site.name);
+      const db = SiteDb.init(dbPath);
+      db.ensureSite(site.name, site.url);
+
+      const debounceMs = options.debounce ?? DEBOUNCE_MS;
+
+      // Track in-flight operations to avoid duplicate processing.
+      const processing = new Set<string>();
+
+      // Debounce timers per file.
+      const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+      info(`Watching ${watchDir} for changes...`);
+      info(`Site: ${site.name} (${site.url})`);
+      if (options.optimize) info(`Optimization: enabled (quality=${options.quality ?? 'default'})`);
+      if (options.to) info(`Convert to: ${options.to}`);
+      info('Press Ctrl+C to stop.\n');
+
+      /**
+       * Process a file: optimize (if requested), then upload to WordPress.
+       */
+      async function processFile(filePath: string, isNew: boolean): Promise<void> {
+        const relPath = relative(watchDir, filePath);
+
+        if (processing.has(filePath)) return;
+        processing.add(filePath);
+
+        try {
+          const file = Bun.file(filePath);
+          if (!(await file.exists())) {
+            processing.delete(filePath);
+            return;
+          }
+
+          let fileBuffer = Buffer.from(await file.arrayBuffer());
+          const originalSize = fileBuffer.length;
+          const hash = fileHash(fileBuffer);
+
+          // Check if we already uploaded this exact file (same hash).
+          const existingMapping = db.getWatchMapping(site.name, watchDir, relPath);
+          if (existingMapping && existingMapping.fileHash === hash) {
+            // File hasn't actually changed (editor may have touched mtime).
+            processing.delete(filePath);
+            return;
+          }
+
+          const filename = basename(filePath);
+          const mime = mimeFromPath(filePath);
+
+          // Optimize if requested.
+          let optimizeInfo = '';
+          if (options.optimize || options.to) {
+            const optimizeOpts = {
+              quality: options.quality,
+              toFormat: options.to as ImageFormat | undefined,
+              maxWidth: options.maxWidth,
+              maxHeight: options.maxHeight,
+            };
+
+            const result = await optimizeImage(fileBuffer, mime, optimizeOpts);
+            const savedPct = (result.savedRatio * 100).toFixed(1);
+            optimizeInfo = ` (${formatBytes(originalSize)} → ${formatBytes(result.after.sizeBytes)}, -${savedPct}%)`;
+            fileBuffer = Buffer.from(result.bytes);
+          }
+
+          // Determine if this is a replace or a new upload.
+          if (!isNew && existingMapping?.wpId) {
+            // Try replace-in-place.
+            const replaceAdapter = resolver.tryResolve('replace-in-place');
+
+            if (replaceAdapter) {
+              try {
+                const result = await replaceAdapter.replaceInPlace(
+                  existingMapping.wpId,
+                  fileBuffer,
+                );
+                db.upsertWatchMapping(site.name, watchDir, relPath, hash, result.id);
+
+                if (parentOpts.json) {
+                  printJson({
+                    event: 'replaced',
+                    file: relPath,
+                    attachmentId: result.id,
+                    sizeBytes: fileBuffer.length,
+                  });
+                } else {
+                  info(`↻ ${relPath} → replaced #${result.id}${optimizeInfo}`);
+                }
+                processing.delete(filePath);
+                return;
+              } catch (err) {
+                if ((err as CapabilityUnavailableError).name !== 'CapabilityUnavailableError') {
+                  throw err;
+                }
+                // Fall through to upload-as-new.
+              }
+            }
+
+            // Fallback: upload as new, update mapping.
+            if (parentOpts.strict) {
+              warn(
+                `Cannot replace #${existingMapping.wpId} in place (no WP-CLI). Skipping ${relPath} (--strict mode).`,
+              );
+              processing.delete(filePath);
+              return;
+            }
+
+            // Upload as new attachment.
+            const uploadAdapter = resolver.resolve('upload');
+            const result = await uploadAdapter.upload(fileBuffer, { filename });
+            db.upsertWatchMapping(site.name, watchDir, relPath, hash, result.id);
+
+            if (parentOpts.json) {
+              printJson({
+                event: 'uploaded-as-new',
+                file: relPath,
+                attachmentId: result.id,
+                previousId: existingMapping.wpId,
+                sizeBytes: fileBuffer.length,
+              });
+            } else {
+              warn(
+                `↻ ${relPath} → uploaded as new #${result.id} (replace unavailable, was #${existingMapping.wpId})${optimizeInfo}`,
+              );
+            }
+          } else {
+            // New file — upload.
+            const uploadAdapter = resolver.resolve('upload');
+            const result = await uploadAdapter.upload(fileBuffer, { filename });
+            db.upsertWatchMapping(site.name, watchDir, relPath, hash, result.id);
+
+            if (parentOpts.json) {
+              printJson({
+                event: 'uploaded',
+                file: relPath,
+                attachmentId: result.id,
+                sizeBytes: fileBuffer.length,
+              });
+            } else {
+              info(`+ ${relPath} → #${result.id}${optimizeInfo}`);
+            }
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (parentOpts.json) {
+            printJson({ event: 'error', file: relPath, error: msg });
+          } else {
+            error(`✗ ${relPath}: ${msg}`);
+          }
+        } finally {
+          processing.delete(filePath);
+        }
+      }
+
+      /**
+       * Handle file deletion.
+       */
+      async function handleDelete(filePath: string): Promise<void> {
+        const relPath = relative(watchDir, filePath);
+        const mapping = db.getWatchMapping(site.name, watchDir, relPath);
+
+        if (!mapping) return;
+
+        if (options.delete) {
+          try {
+            const deleteAdapter = resolver.resolve('delete');
+            await deleteAdapter.delete(mapping.wpId);
+            db.removeWatchMapping(site.name, watchDir, relPath);
+
+            if (parentOpts.json) {
+              printJson({ event: 'deleted', file: relPath, attachmentId: mapping.wpId });
+            } else {
+              info(`- ${relPath} → deleted #${mapping.wpId} from WordPress`);
+            }
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            error(`✗ Could not delete #${mapping.wpId}: ${msg}`);
+          }
+        } else {
+          if (parentOpts.json) {
+            printJson({
+              event: 'file-removed',
+              file: relPath,
+              attachmentId: mapping.wpId,
+              note: 'WordPress attachment not deleted (pass --delete to enable)',
+            });
+          } else {
+            warn(
+              `${relPath} removed locally. Attachment #${mapping.wpId} still exists in WordPress. Pass --delete to auto-remove.`,
+            );
+          }
+          // Remove the mapping so we don't try to replace a stale ID later.
+          db.removeWatchMapping(site.name, watchDir, relPath);
+        }
+      }
+
+      /**
+       * Debounced file event handler.
+       */
+      function scheduleProcess(filePath: string, isNew: boolean): void {
+        if (!isImageFile(filePath)) return;
+
+        const existing = debounceTimers.get(filePath);
+        if (existing) clearTimeout(existing);
+
+        debounceTimers.set(
+          filePath,
+          setTimeout(() => {
+            debounceTimers.delete(filePath);
+            void processFile(filePath, isNew);
+          }, debounceMs),
+        );
+      }
+
+      // Start watching.
+      const watcher = watch(watchDir, {
+        ignoreInitial: true,
+        persistent: true,
+        usePolling: false,
+        awaitWriteFinish: {
+          stabilityThreshold: debounceMs,
+          pollInterval: 100,
+        },
+        ignored: [
+          /(^|[/\\])\../, // dotfiles
+          '**/node_modules/**',
+          '**/.git/**',
+        ],
+      });
+
+      watcher.on('add', (filePath) => scheduleProcess(filePath, true));
+      watcher.on('change', (filePath) => scheduleProcess(filePath, false));
+      watcher.on('unlink', (filePath) => {
+        if (!isImageFile(filePath)) return;
+        void handleDelete(filePath);
+      });
+      watcher.on('error', (err) => {
+        error(`Watcher error: ${err.message}`);
+      });
+
+      // Graceful shutdown on Ctrl+C.
+      const shutdown = async () => {
+        info('\nStopping watcher...');
+        for (const timer of debounceTimers.values()) {
+          clearTimeout(timer);
+        }
+        await watcher.close();
+        db.close();
+        process.exit(0);
+      };
+
+      process.on('SIGINT', () => void shutdown());
+      process.on('SIGTERM', () => void shutdown());
+
+      // Keep the process alive.
+      await new Promise(() => {});
+    });
+}
+
+// -- Helpers ------------------------------------------------------------------
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -29,6 +29,7 @@ import { registerShowCommand } from './commands/show.ts';
 import { registerSitesCommand } from './commands/sites.ts';
 import { registerStatsCommand } from './commands/stats.ts';
 import { registerUpdateCommand } from './commands/update.ts';
+import { registerWatchCommand } from './commands/watch.ts';
 import { setOutputOptions } from './utils/output.ts';
 
 const program = new Command();
@@ -80,6 +81,7 @@ registerPushCommand(program);
 registerReferencesCommand(program);
 registerRegenerateCommand(program);
 registerUpdateCommand(program);
+registerWatchCommand(program);
 registerCompletionsCommand(program);
 
 // Top-level help footer.

--- a/src/engine/state/db.ts
+++ b/src/engine/state/db.ts
@@ -371,6 +371,63 @@ export class SiteDb {
       [siteName, key, value, Date.now()],
     );
   }
+
+  // Watch mappings (file→attachment tracking) ---------------------------------
+
+  /** Get the watch mapping for a file path in a watched directory. */
+  getWatchMapping(siteName: string, watchDir: string, relPath: string): WatchMapping | null {
+    const row = this.db
+      .query(
+        `SELECT site_name, watch_dir, rel_path, file_hash, wp_id, updated_at
+         FROM watch_mappings
+         WHERE site_name = ? AND watch_dir = ? AND rel_path = ?`,
+      )
+      .get(siteName, watchDir, relPath) as RawWatchMappingRow | null;
+
+    return row ? mapWatchMappingRow(row) : null;
+  }
+
+  /** Upsert a watch mapping (file→attachment). */
+  upsertWatchMapping(
+    siteName: string,
+    watchDir: string,
+    relPath: string,
+    fileHash: string,
+    wpId: number,
+  ): void {
+    this.db.run(
+      `INSERT INTO watch_mappings (site_name, watch_dir, rel_path, file_hash, wp_id, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT (site_name, watch_dir, rel_path) DO UPDATE SET
+         file_hash  = excluded.file_hash,
+         wp_id      = excluded.wp_id,
+         updated_at = excluded.updated_at`,
+      [siteName, watchDir, relPath, fileHash, wpId, Date.now()],
+    );
+  }
+
+  /** Remove a watch mapping (e.g. when a file is deleted). */
+  removeWatchMapping(siteName: string, watchDir: string, relPath: string): void {
+    this.db.run(
+      `DELETE FROM watch_mappings
+       WHERE site_name = ? AND watch_dir = ? AND rel_path = ?`,
+      [siteName, watchDir, relPath],
+    );
+  }
+
+  /** List all watch mappings for a directory. */
+  listWatchMappings(siteName: string, watchDir: string): WatchMapping[] {
+    const rows = this.db
+      .query(
+        `SELECT site_name, watch_dir, rel_path, file_hash, wp_id, updated_at
+         FROM watch_mappings
+         WHERE site_name = ? AND watch_dir = ?
+         ORDER BY rel_path ASC`,
+      )
+      .all(siteName, watchDir) as RawWatchMappingRow[];
+
+    return rows.map(mapWatchMappingRow);
+  }
 }
 
 // -- Internal row types and mappers -------------------------------------------
@@ -519,3 +576,34 @@ export function getStoredSchemaVersion(db: Database): number {
 
 // Re-export for convenience.
 export { SCHEMA_VERSION, INITIAL_SCHEMA, MIGRATIONS };
+
+// -- Watch mapping types ------------------------------------------------------
+
+export interface WatchMapping {
+  siteName: string;
+  watchDir: string;
+  relPath: string;
+  fileHash: string;
+  wpId: number;
+  updatedAt: number;
+}
+
+interface RawWatchMappingRow {
+  site_name: string;
+  watch_dir: string;
+  rel_path: string;
+  file_hash: string;
+  wp_id: number;
+  updated_at: number;
+}
+
+function mapWatchMappingRow(row: RawWatchMappingRow): WatchMapping {
+  return {
+    siteName: row.site_name,
+    watchDir: row.watch_dir,
+    relPath: row.rel_path,
+    fileHash: row.file_hash,
+    wpId: row.wp_id,
+    updatedAt: row.updated_at,
+  };
+}

--- a/src/engine/state/schema.ts
+++ b/src/engine/state/schema.ts
@@ -15,7 +15,7 @@
  * On startup, the DB layer compares this against the stored value and applies
  * pending migrations.
  */
-export const SCHEMA_VERSION = 2;
+export const SCHEMA_VERSION = 3;
 
 /**
  * Initial schema (v1). Idempotent — safe to run on every CLI invocation.
@@ -101,6 +101,25 @@ export const MIGRATIONS: Migration[] = [
         PRIMARY KEY (site_name, key),
         FOREIGN KEY (site_name) REFERENCES sites(name) ON DELETE CASCADE
       );
+    `,
+  },
+  {
+    version: 3,
+    description: 'Add watch_mappings table for directory watch file→attachment tracking',
+    up: `
+      CREATE TABLE IF NOT EXISTS watch_mappings (
+        site_name   TEXT NOT NULL,
+        watch_dir   TEXT NOT NULL,
+        rel_path    TEXT NOT NULL,
+        file_hash   TEXT NOT NULL,
+        wp_id       INTEGER NOT NULL,
+        updated_at  INTEGER NOT NULL,
+        PRIMARY KEY (site_name, watch_dir, rel_path),
+        FOREIGN KEY (site_name) REFERENCES sites(name) ON DELETE CASCADE
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_watch_mappings_wp_id
+        ON watch_mappings(site_name, wp_id);
     `,
   },
 ];

--- a/test/unit/db.test.ts
+++ b/test/unit/db.test.ts
@@ -36,7 +36,7 @@ describe('SiteDb.init', () => {
     // Access the underlying Database to check the version.
     // We use getStoredSchemaVersion via a fresh Database connection.
     // Since we're using :memory:, we verify via the SiteDb's own state.
-    expect(SCHEMA_VERSION).toBe(2);
+    expect(SCHEMA_VERSION).toBe(3);
     db.close();
   });
 });

--- a/test/unit/smoke.test.ts
+++ b/test/unit/smoke.test.ts
@@ -44,8 +44,8 @@ describe('exit codes', () => {
 });
 
 describe('schema', () => {
-  test('initial schema version is 2', () => {
-    expect(SCHEMA_VERSION).toBe(2);
+  test('initial schema version is 3', () => {
+    expect(SCHEMA_VERSION).toBe(3);
   });
 });
 


### PR DESCRIPTION
Closes #3

## Summary

Adds the `localpress watch` command — a continuous directory watcher that automatically pushes new/changed images to WordPress.

## Usage

```bash
# Basic: watch a directory, push new/changed images
localpress watch ./assets/images --site production

# With optimization pipeline
localpress watch ./product-photos --optimize --quality 80

# Convert to WebP on upload
localpress watch ./uploads --to webp

# Auto-delete from WP when local files are removed
localpress watch ./media --delete
```

## Behavior

| Event | Action |
|-------|--------|
| New file | Upload as new attachment |
| Changed file | Replace-in-place (WP-CLI) or upload-as-new (REST fallback) |
| Deleted file | Warn (default) or delete from WP (`--delete`) |

## Implementation

- **Watcher**: chokidar with `awaitWriteFinish` stabilization (handles atomic saves from editors)
- **Deduplication**: SHA-256 hash comparison — skips re-upload if content hasn't changed
- **State**: New `watch_mappings` SQLite table (migration v3) persists file→attachment mappings across restarts
- **Optimization**: Optional `--optimize` / `--to` / `--max-width` / `--max-height` flags run the image pipeline before upload
- **Output**: Full `--json` support for agent/skill consumption

## New flags

| Flag | Description |
|------|-------------|
| `--optimize` | Run optimization pipeline before upload |
| `--quality <n>` | Quality (1-100) for optimization |
| `--to <format>` | Convert to format (webp, avif, jpeg, png) |
| `--max-width <n>` | Max width in pixels |
| `--max-height <n>` | Max height in pixels |
| `--delete` | Delete from WordPress when local file is removed |
| `--debounce <ms>` | Debounce interval (default: 800ms) |

## Testing

- All 114 existing unit tests pass
- Typecheck clean
- Lint clean
- Shell completions updated (bash, zsh, fish)
