### PR TITLE
fix: platform-specific deps reduce tarball from 648MB to ~106MB

### DIFF
--- a/scripts/build-tarball.ts
+++ b/scripts/build-tarball.ts
@@ -97,9 +97,16 @@ async function buildTarball(opts: BuildOptions): Promise<void> {
   // 4. Install production dependencies
   console.log('  Installing production dependencies (this may take a minute)...');
   const [os, arch] = parsePlatform(platform);
+
+  // Set npm_config_os and npm_config_cpu env vars so npm only installs
+  // platform-specific optional deps (e.g. only darwin-arm64 sharp binaries,
+  // not all 8 platform variants). This is the correct way to cross-install.
   const installEnv = {
     ...process.env,
-    // Force bun/npm to install the right platform-specific packages for sharp
+    npm_config_os: os,
+    npm_config_cpu: arch,
+    // Also set libc for Linux musl detection
+    ...(os === 'linux' ? { npm_config_libc: 'glibc' } : {}),
   };
 
   // Use npm with explicit --os and --cpu flags so cross-platform builds install the right sharp binaries


### PR DESCRIPTION
## Problem

CI builds on ubuntu-latest were installing all 8 platform variants of sharp's native binaries (darwin-arm64, darwin-x64, linux-arm64, linux-x64, linuxmusl-arm64, linuxmusl-x64, win32-ia32, win32-x64), resulting in 648MB tarballs.

## Fix

Set `npm_config_os` and `npm_config_cpu` environment variables during `npm install`. These env vars are the correct way to filter optional dependencies for cross-platform builds — the `--os` and `--cpu` CLI flags alone don't prevent npm from installing all platform variants.

## Result

Each tarball now only includes its target platform's sharp binaries:
- darwin-arm64: only `@img/sharp-darwin-arm64` + `@img/sharp-libvips-darwin-arm64`
- linux-x64: only `@img/sharp-linux-x64` + `@img/sharp-libvips-linux-x64`
- etc.

**Before:** ~648MB per tarball  
**After:** ~106MB per tarball

Verified locally: `localpress doctor` shows `✓ sharp (image processing)` after build.