### PR TITLE
fix: re-fetch item after optimize to show fresh metadata in browser

### DIFF
--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -127,6 +127,9 @@ export function registerListCommand(program: Command): void {
         };
 
         // Loop: re-enter the TUI after each subcommand until the user quits.
+        // Track the last processed item ID so we can refresh it after the page re-fetch.
+        let lastProcessedId: number | null = null;
+
         while (true) {
           let result: { items: MediaItem[]; total: number; totalPages: number };
 
@@ -149,6 +152,23 @@ export function registerListCommand(program: Command): void {
           if (result.items.length === 0 && interactivePage === 1) {
             info('No media items found.');
             return;
+          }
+
+          // If we just processed an item, re-fetch it individually to get fresh
+          // metadata (mimeType, sizeBytes, dimensions). The page-level REST API
+          // response may be cached by WordPress and return stale data.
+          if (lastProcessedId !== null) {
+            try {
+              const getAdapter = resolver.resolve('get');
+              const refreshed = await getAdapter.getMedia(lastProcessedId);
+              const idx = result.items.findIndex((i) => i.id === lastProcessedId);
+              if (idx >= 0) {
+                result.items[idx] = refreshed;
+              }
+            } catch {
+              // Best effort — stale data is better than crashing.
+            }
+            lastProcessedId = null;
           }
 
           if (options.unoptimized) {
@@ -304,9 +324,27 @@ export function registerListCommand(program: Command): void {
             'remove-bg',
             'caption',
           ]);
-          if (processingTypes.has(pendingAction.type)) processedIds = loadProcessedIds();
+          if (processingTypes.has(pendingAction.type)) {
+            processedIds = loadProcessedIds();
+            // Mark this item for individual re-fetch on next loop iteration.
+            lastProcessedId = pendingAction.id;
+          }
+
+          // Store the ID of the item that was just processed so we can
+          // refresh it after the next page fetch (bypasses REST API cache).
+          const justProcessedId = processingTypes.has(pendingAction.type) ? pendingAction.id : null;
 
           process.stdout.write('\x1b[2J\x1b[H');
+
+          // The loop will re-fetch the page at the top. After that fetch,
+          // we patch the specific item with a fresh getMedia() call to ensure
+          // we show updated metadata (mimeType, sizeBytes, dimensions) even
+          // if WordPress's REST API returns a cached page response.
+          if (justProcessedId !== null) {
+            // We'll handle this at the top of the next loop iteration.
+            // Store it in a variable accessible to the next iteration.
+            // (We use a closure variable declared outside the loop.)
+          }
         }
 
         return;


### PR DESCRIPTION
## Problem

After optimizing an attachment in `list -i` (e.g. PNG → WebP, 1.4MB → 114KB), the browser still shows the old metadata (PNG, 1.4MB) when you return to the list.

## Root Cause

The interactive browser loop re-fetches the full page from the REST API after each subcommand. However, WordPress's REST API caches page-level responses, so the re-fetch returns stale data for the recently-modified attachment.

## Fix

After the page re-fetch, if we just processed an item, call `getMedia(id)` individually to get fresh metadata for that specific attachment. Individual item fetches bypass the page-level cache.

```
1. User presses [o] to optimize #2204 (PNG → WebP)
2. Optimize subcommand runs, replaces file in WordPress
3. User presses any key to return
4. Browser re-fetches the page (may return cached PNG/1.4MB data)
5. NEW: getMedia(2204) is called individually → returns fresh WebP/114KB data
6. result.items[idx] is patched with the fresh data
7. Browser renders with correct WebP/114KB metadata
```

## Testing

```
bun run typecheck  →  clean
bun run lint       →  clean
bun test test/unit →  114 pass
```
