### PR TITLE
fix: show fresh metadata in browser preview after apply

### DIFF
--- a/src/cli/commands/optimize.ts
+++ b/src/cli/commands/optimize.ts
@@ -219,7 +219,24 @@ export function registerOptimizeCommand(program: Command): void {
               resultWpId: resultWpId !== item.id ? resultWpId : null,
             });
             db.close();
-            return { wpId: resultWpId, message: `Uploaded as #${resultWpId}` };
+
+            // Re-fetch the item from WordPress to get fresh metadata for the UI.
+            let freshItem: import('../../engine/preview/server.ts').ApplyResult['freshItem'];
+            try {
+              const refreshed = await getAdapter.getMedia(resultWpId ?? id);
+              freshItem = {
+                filename: refreshed.filename,
+                mimeType: refreshed.mimeType,
+                sizeBytes: refreshed.sizeBytes,
+                width: refreshed.width,
+                height: refreshed.height,
+                url: refreshed.url,
+              };
+            } catch {
+              // Best effort — UI will show basic success without fresh metadata.
+            }
+
+            return { wpId: resultWpId, message: `Uploaded as #${resultWpId}`, freshItem };
           },
         });
 

--- a/src/engine/preview/server.ts
+++ b/src/engine/preview/server.ts
@@ -55,6 +55,15 @@ export interface ProcessResult {
 export interface ApplyResult {
   wpId: number;
   message: string;
+  /** Fresh metadata from WordPress after the upload — for UI display. */
+  freshItem?: {
+    filename: string;
+    mimeType: string;
+    sizeBytes?: number;
+    width?: number;
+    height?: number;
+    url: string;
+  };
 }
 
 /**

--- a/src/engine/preview/ui-optimize.ts
+++ b/src/engine/preview/ui-optimize.ts
@@ -375,7 +375,16 @@ export function buildOptimizeHtml(): string {
       const res = await fetch('/api/apply', { method: 'POST' }); const data = await res.json();
       if (data.error) { showToast(data.error, 'error'); btnApply.disabled = false; btnApply.textContent = 'Apply & Upload to WordPress'; return; }
       showToast('Uploaded as #' + data.wpId, 'success'); btnApply.textContent = 'Applied ✓';
-      setTimeout(() => { document.body.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100vh;flex-direction:column;gap:12px;color:#e4e6ef;font-family:sans-serif"><h2 style="color:#22c55e">✓ Applied</h2><p style="color:#8b8fa3">Uploaded as #' + data.wpId + '. You can close this tab.</p></div>'; }, 1500);
+      // Build success message with fresh metadata if available
+      let successDetails = 'Uploaded as #' + data.wpId + '.';
+      if (data.freshItem) {
+        const fi = data.freshItem;
+        const sizeStr = fi.sizeBytes ? ' · ' + formatBytes(fi.sizeBytes) : '';
+        const dimsStr = (fi.width && fi.height) ? ' · ' + fi.width + '×' + fi.height : '';
+        const fmtStr = fi.mimeType ? ' · ' + fi.mimeType.replace('image/', '').toUpperCase() : '';
+        successDetails = 'Uploaded as #' + data.wpId + fmtStr + sizeStr + dimsStr + '.';
+      }
+      setTimeout(() => { document.body.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100vh;flex-direction:column;gap:12px;color:#e4e6ef;font-family:sans-serif"><h2 style="color:#22c55e">✓ Applied</h2><p style="color:#8b8fa3">' + successDetails + ' You can close this tab.</p></div>'; }, 1500);
     } catch (err) { showToast('Upload failed: ' + err.message, 'error'); btnApply.disabled = false; btnApply.textContent = 'Apply & Upload to WordPress'; }
   }
   async function cancelPreview() {


### PR DESCRIPTION
After clicking 'Apply & Upload' in the browser preview, the success screen now shows the actual file format, size, and dimensions from WordPress.

**Before:** `✓ Applied — Uploaded as #2204. You can close this tab.`

**After:** `✓ Applied — Uploaded as #2204 · WEBP · 114.2 KB · 1672×941. You can close this tab.`

The `onApply` callback re-fetches the item from WordPress after upload to get fresh metadata, which is returned to the browser UI via the extended `ApplyResult` interface.