### PR TITLE
feat: wire --profile flag into optimize command

### DIFF
--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -185,6 +185,15 @@ export function registerListCommand(program: Command): void {
               processedIds,
               sortBy: filters.sortBy,
               sortOrder: filters.sortOrder,
+              profiles: config.profiles
+                ? Object.entries(config.profiles).map(([name, p]) => ({
+                    name,
+                    quality: p.quality,
+                    format: p.format,
+                    maxWidth: p.maxWidth,
+                    maxHeight: p.maxHeight,
+                  }))
+                : undefined,
               onFetchItem: (id: number) => adapter.getMedia(id),
               onOpenInBrowser: openInBrowser,
               onAction: (action) => {

--- a/src/cli/commands/optimize.ts
+++ b/src/cli/commands/optimize.ts
@@ -73,12 +73,38 @@ export function registerOptimizeCommand(program: Command): void {
       '--regenerate-thumbnails',
       'regenerate WordPress thumbnails after replace-in-place (slower)',
     )
+    .option('--profile <name>', 'use a named optimization profile (from localpress config)')
     .action(async (idStrs: string[], options) => {
       const parentOpts = program.opts();
       const config = await loadConfig();
       const site = resolveActiveSite(config, parentOpts.site);
       const resolver = new AdapterResolver(site);
       const adapter = resolver.resolve('list');
+
+      // Resolve named profile (if --profile is passed).
+      let profileQuality: number | undefined;
+      let profileFormat: ImageFormat | undefined;
+      let profileMaxWidth: number | undefined;
+      let profileMaxHeight: number | undefined;
+      let profileEncoder: 'sharp' | 'jsquash' | undefined;
+      let profileStripMetadata: boolean | undefined;
+
+      if (options.profile) {
+        const profile = config.profiles?.[options.profile];
+        if (!profile) {
+          error(
+            `Profile '${options.profile}' not found. Available profiles: ${Object.keys(config.profiles ?? {}).join(', ') || '(none)'}.\n` +
+              `Create one with: localpress config set-profile ${options.profile} --quality 75 --format webp`,
+          );
+          process.exit(3);
+        }
+        profileQuality = profile.quality;
+        profileFormat = profile.format as ImageFormat | undefined;
+        profileMaxWidth = profile.maxWidth;
+        profileMaxHeight = profile.maxHeight;
+        profileEncoder = profile.encoder;
+        profileStripMetadata = profile.stripMetadata;
+      }
 
       const hasExplicitIds = idStrs.length > 0;
       const isBulk = options.all || options.unoptimized;
@@ -136,6 +162,19 @@ export function registerOptimizeCommand(program: Command): void {
 
         info(`  Starting preview for #${id} (${item.filename})...`);
 
+        // Pass available profiles to the browser UI.
+        const profiles = config.profiles
+          ? Object.entries(config.profiles).map(([name, p]) => ({
+              name,
+              quality: p.quality,
+              format: p.format,
+              maxWidth: p.maxWidth,
+              maxHeight: p.maxHeight,
+              encoder: p.encoder,
+              description: p.description,
+            }))
+          : [];
+
         const { applied, result } = await startPreviewServer({
           port: options.previewPort ?? 0,
           sourceBytes,
@@ -146,6 +185,7 @@ export function registerOptimizeCommand(program: Command): void {
           wpId: id,
           mode: 'optimize',
           html: buildOptimizeHtml(),
+          extraMeta: { profiles, activeProfile: options.profile ?? null },
           onProcess: async (params): Promise<ProcessResult> => {
             const opts: OptimizeOptions = {
               toFormat:
@@ -340,12 +380,15 @@ export function registerOptimizeCommand(program: Command): void {
       }
 
       // Build optimization options.
+      // Priority: explicit CLI flags > profile values > built-in defaults.
       const optimizeOpts: OptimizeOptions = {
-        toFormat: options.to as ImageFormat | undefined,
+        toFormat: (options.to as ImageFormat | undefined) ?? profileFormat,
         mode: options.mode,
-        quality: options.quality,
-        stripMetadata: true,
-        encoder: options.encoder === 'jsquash' ? 'jsquash' : 'sharp',
+        quality: options.quality ?? profileQuality,
+        maxWidth: profileMaxWidth,
+        maxHeight: profileMaxHeight,
+        stripMetadata: profileStripMetadata ?? true,
+        encoder: options.encoder === 'jsquash' ? 'jsquash' : (profileEncoder ?? 'sharp'),
       };
 
       // Open the site DB for recording processing history.

--- a/src/cli/components/MediaBrowser.tsx
+++ b/src/cli/components/MediaBrowser.tsx
@@ -72,6 +72,14 @@ interface Props {
   onPageChange: (page: number) => Promise<PagedResult<MediaItem>>;
   onFetchItem?: (id: number) => Promise<MediaItem>;
   onOpenInBrowser?: (id: number) => void;
+  /** Available optimization profiles from config. */
+  profiles?: Array<{
+    name: string;
+    quality?: number;
+    format?: string;
+    maxWidth?: number;
+    maxHeight?: number;
+  }>;
 }
 
 const SIDEBAR_WIDTH = 38;
@@ -125,6 +133,7 @@ export function MediaBrowser({
   onPageChange,
   onFetchItem,
   onOpenInBrowser,
+  profiles,
 }: Props) {
   const { exit } = useApp();
 
@@ -160,9 +169,10 @@ export function MediaBrowser({
   const [optimizeQuality, setOptimizeQuality] = useState('');
   const [optimizeFormat, setOptimizeFormat] = useState<OptimizeFormat>('keep');
   const [optimizeKeepOriginal, setOptimizeKeepOriginal] = useState(false);
-  const [optimizeActiveField, setOptimizeActiveField] = useState<'quality' | 'format' | 'keep'>(
-    'quality',
-  );
+  const [optimizeActiveField, setOptimizeActiveField] = useState<
+    'profile' | 'quality' | 'format' | 'keep'
+  >('profile');
+  const [optimizeProfile, setOptimizeProfile] = useState('');
 
   // Convert format picker overlay ([c]) — two-step: format then quality.
   const [convertMode, setConvertMode] = useState(false);
@@ -300,16 +310,57 @@ export function MediaBrowser({
         setOptimizeQuality('');
         setOptimizeFormat('keep');
         setOptimizeKeepOriginal(false);
-        setOptimizeActiveField('quality');
+        setOptimizeActiveField('profile');
+        setOptimizeProfile('');
         return;
       }
       if (key.tab) {
         setOptimizeActiveField((f) => {
+          if (f === 'profile') return 'quality';
           if (f === 'quality') return 'format';
           if (f === 'format') return 'keep';
-          return 'quality';
+          return 'profile';
         });
         return;
+      }
+      if (optimizeActiveField === 'profile') {
+        if (profiles && profiles.length > 0) {
+          const profileNames = ['', ...profiles.map((p) => p.name)];
+          const idx = profileNames.indexOf(optimizeProfile);
+          if (key.rightArrow || input === ' ') {
+            const next = profileNames[(idx + 1) % profileNames.length];
+            setOptimizeProfile(next);
+            // Apply profile values as defaults.
+            if (next) {
+              const p = profiles.find((pr) => pr.name === next);
+              if (p) {
+                if (p.quality) setOptimizeQuality(String(p.quality));
+                if (p.format && OPTIMIZE_FORMATS.includes(p.format as OptimizeFormat)) {
+                  setOptimizeFormat(p.format as OptimizeFormat);
+                }
+              }
+            }
+            return;
+          }
+          if (key.leftArrow) {
+            const next = profileNames[(idx - 1 + profileNames.length) % profileNames.length];
+            setOptimizeProfile(next);
+            if (next) {
+              const p = profiles.find((pr) => pr.name === next);
+              if (p) {
+                if (p.quality) setOptimizeQuality(String(p.quality));
+                if (p.format && OPTIMIZE_FORMATS.includes(p.format as OptimizeFormat)) {
+                  setOptimizeFormat(p.format as OptimizeFormat);
+                }
+              }
+            }
+            return;
+          }
+        }
+        if (key.return) {
+          setOptimizeActiveField('quality');
+          return;
+        }
       }
       if (optimizeActiveField === 'quality') {
         if (key.backspace || key.delete) {
@@ -354,7 +405,8 @@ export function MediaBrowser({
         setOptimizeQuality('');
         setOptimizeFormat('keep');
         setOptimizeKeepOriginal(false);
-        setOptimizeActiveField('quality');
+        setOptimizeActiveField('profile');
+        setOptimizeProfile('');
         doExit({ type: 'optimize', id: item.id, page, cursor, quality, to, keepOriginal, preview });
       }
       return;
@@ -643,6 +695,27 @@ export function MediaBrowser({
         <Box flexDirection="column" paddingX={2} paddingY={1} gap={1}>
           <Text dimColor>Leave fields blank to use defaults. [Tab] to move between fields.</Text>
           <Text> </Text>
+
+          {/* Profile field */}
+          {profiles && profiles.length > 0 && (
+            <Box gap={2} alignItems="center">
+              <Text
+                color={optimizeActiveField === 'profile' ? 'green' : undefined}
+                dimColor={optimizeActiveField !== 'profile'}
+                bold={optimizeActiveField === 'profile'}
+              >
+                Profile:
+              </Text>
+              <Text
+                color={optimizeProfile ? 'green' : undefined}
+                dimColor={!optimizeProfile}
+                inverse={optimizeActiveField === 'profile'}
+              >
+                {optimizeProfile || '(none)'}
+              </Text>
+              {optimizeActiveField === 'profile' && <Text dimColor> ← → or space to cycle</Text>}
+            </Box>
+          )}
 
           {/* Quality field */}
           <Box gap={2} alignItems="center">

--- a/src/engine/preview/server.ts
+++ b/src/engine/preview/server.ts
@@ -44,6 +44,8 @@ export interface PreviewServerOptions {
   timeoutMs?: number;
   /** HTML content for the UI page. */
   html: string;
+  /** Extra metadata to include in the /api/meta response (e.g. profiles). */
+  extraMeta?: Record<string, unknown>;
 }
 
 export interface ProcessResult {
@@ -227,6 +229,7 @@ export async function startPreviewServer(
             height: options.height,
             sizeBytes: options.sourceBytes.length,
             wpId: options.wpId,
+            ...(options.extraMeta ?? {}),
           }),
           { headers: { 'Content-Type': 'application/json' } },
         );

--- a/src/engine/preview/ui-optimize.ts
+++ b/src/engine/preview/ui-optimize.ts
@@ -170,6 +170,15 @@ export function buildOptimizeHtml(): string {
   </div>
   <div class="sidebar">
     <div class="sidebar-section">
+      <h3>Profile</h3>
+      <div class="control-group">
+        <label>Optimization profile</label>
+        <select id="profile" onchange="applyProfile()">
+          <option value="">— None (manual settings) —</option>
+        </select>
+      </div>
+    </div>
+    <div class="sidebar-section">
       <h3>Format</h3>
       <div class="control-group">
         <label>Output format</label>
@@ -264,7 +273,52 @@ export function buildOptimizeHtml(): string {
       meta.width && meta.height ? meta.width + '×' + meta.height + 'px' : '',
       formatBytes(meta.sizeBytes),
     ].filter(Boolean).join('  ·  ');
+
+    // Populate profile dropdown if profiles are available.
+    if (meta.profiles && meta.profiles.length > 0) {
+      const sel = document.getElementById('profile');
+      for (const p of meta.profiles) {
+        const opt = document.createElement('option');
+        opt.value = p.name;
+        const parts = [p.name];
+        if (p.description) parts[0] += ' — ' + p.description;
+        else {
+          const hints = [];
+          if (p.quality) hints.push('q' + p.quality);
+          if (p.format) hints.push(p.format);
+          if (p.maxWidth) hints.push(p.maxWidth + 'px');
+          if (hints.length) parts[0] += ' (' + hints.join(', ') + ')';
+        }
+        opt.textContent = parts[0];
+        sel.appendChild(opt);
+      }
+      // Pre-select active profile if one was passed via CLI.
+      if (meta.activeProfile) {
+        sel.value = meta.activeProfile;
+        applyProfile();
+      }
+    } else {
+      // Hide profile section if no profiles exist.
+      document.getElementById('profile').closest('.sidebar-section').style.display = 'none';
+    }
+
     showSourceImage();
+  }
+
+  function applyProfile() {
+    const sel = document.getElementById('profile');
+    const name = sel.value;
+    if (!name || !meta.profiles) return;
+    const profile = meta.profiles.find(p => p.name === name);
+    if (!profile) return;
+    if (profile.quality) { qualityInput.value = profile.quality; qualityValue.textContent = profile.quality; }
+    if (profile.format) { document.getElementById('format').value = profile.format; }
+    else { document.getElementById('format').value = 'keep'; }
+    if (profile.encoder) { document.getElementById('encoder').value = profile.encoder; }
+    if (profile.maxWidth) { document.getElementById('max-width').value = profile.maxWidth; }
+    else { document.getElementById('max-width').value = ''; }
+    if (profile.maxHeight) { document.getElementById('max-height').value = profile.maxHeight; }
+    else { document.getElementById('max-height').value = ''; }
   }
 
   function clearCanvas() {

--- a/test/unit/export-import.test.ts
+++ b/test/unit/export-import.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Unit tests for export/import internal utilities.
+ *
+ * Tests the ZIP builder (export) and ZIP parser (import) to ensure
+ * round-trip integrity — files exported as ZIP can be re-imported.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Minimal ZIP builder — extracted from export.ts for testing.
+ * Uses STORE method (no compression) for speed.
+ */
+function buildZipSync(entries: Array<{ path: string; data: Buffer }>): Buffer {
+  const parts: Buffer[] = [];
+  const centralDir: Buffer[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const pathBuf = Buffer.from(entry.path, 'utf-8');
+    const data = entry.data;
+
+    const localHeader = Buffer.alloc(30 + pathBuf.length);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4);
+    localHeader.writeUInt16LE(0, 6);
+    localHeader.writeUInt16LE(0, 8);
+    localHeader.writeUInt16LE(0, 10);
+    localHeader.writeUInt16LE(0, 12);
+    const crc = crc32(data);
+    localHeader.writeUInt32LE(crc, 14);
+    localHeader.writeUInt32LE(data.length, 18);
+    localHeader.writeUInt32LE(data.length, 22);
+    localHeader.writeUInt16LE(pathBuf.length, 26);
+    localHeader.writeUInt16LE(0, 28);
+    pathBuf.copy(localHeader, 30);
+
+    parts.push(localHeader, data);
+
+    const cdEntry = Buffer.alloc(46 + pathBuf.length);
+    cdEntry.writeUInt32LE(0x02014b50, 0);
+    cdEntry.writeUInt16LE(20, 4);
+    cdEntry.writeUInt16LE(20, 6);
+    cdEntry.writeUInt16LE(0, 8);
+    cdEntry.writeUInt16LE(0, 10);
+    cdEntry.writeUInt16LE(0, 12);
+    cdEntry.writeUInt16LE(0, 14);
+    cdEntry.writeUInt32LE(crc, 16);
+    cdEntry.writeUInt32LE(data.length, 20);
+    cdEntry.writeUInt32LE(data.length, 24);
+    cdEntry.writeUInt16LE(pathBuf.length, 28);
+    cdEntry.writeUInt16LE(0, 30);
+    cdEntry.writeUInt16LE(0, 32);
+    cdEntry.writeUInt16LE(0, 34);
+    cdEntry.writeUInt16LE(0, 36);
+    cdEntry.writeUInt32LE(0, 38);
+    cdEntry.writeUInt32LE(offset, 42);
+    pathBuf.copy(cdEntry, 46);
+
+    centralDir.push(cdEntry);
+    offset += localHeader.length + data.length;
+  }
+
+  const centralDirBuf = Buffer.concat(centralDir);
+  const centralDirOffset = offset;
+
+  const endRecord = Buffer.alloc(22);
+  endRecord.writeUInt32LE(0x06054b50, 0);
+  endRecord.writeUInt16LE(0, 4);
+  endRecord.writeUInt16LE(0, 6);
+  endRecord.writeUInt16LE(entries.length, 8);
+  endRecord.writeUInt16LE(entries.length, 10);
+  endRecord.writeUInt32LE(centralDirBuf.length, 12);
+  endRecord.writeUInt32LE(centralDirOffset, 16);
+  endRecord.writeUInt16LE(0, 20);
+
+  return Buffer.concat([...parts, centralDirBuf, endRecord]);
+}
+
+/**
+ * Minimal ZIP parser — extracted from import.ts for testing.
+ */
+function parseZip(buffer: Buffer): Array<{ path: string; data: Buffer }> {
+  const entries: Array<{ path: string; data: Buffer }> = [];
+  let offset = 0;
+
+  while (offset < buffer.length - 4) {
+    const sig = buffer.readUInt32LE(offset);
+    if (sig !== 0x04034b50) break;
+
+    const compressedSize = buffer.readUInt32LE(offset + 18);
+    const filenameLen = buffer.readUInt16LE(offset + 26);
+    const extraLen = buffer.readUInt16LE(offset + 28);
+
+    const filenameStart = offset + 30;
+    const filename = buffer.toString('utf-8', filenameStart, filenameStart + filenameLen);
+    const dataStart = filenameStart + filenameLen + extraLen;
+
+    if (compressedSize > 0) {
+      const data = buffer.subarray(dataStart, dataStart + compressedSize);
+      entries.push({ path: filename, data: Buffer.from(data) });
+    }
+
+    offset = dataStart + compressedSize;
+  }
+
+  return entries;
+}
+
+function crc32(buf: Buffer): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) {
+    crc ^= buf[i];
+    for (let j = 0; j < 8; j++) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+describe('ZIP round-trip', () => {
+  test('single file round-trips correctly', () => {
+    const original = Buffer.from('Hello, localpress!');
+    const zip = buildZipSync([{ path: 'test.txt', data: original }]);
+    const parsed = parseZip(zip);
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].path).toBe('test.txt');
+    expect(parsed[0].data.toString()).toBe('Hello, localpress!');
+  });
+
+  test('multiple files round-trip correctly', () => {
+    const entries = [
+      { path: '2026/01/hero.jpg', data: Buffer.from('fake-jpeg-data-1') },
+      { path: '2026/05/logo.png', data: Buffer.from('fake-png-data-2') },
+      { path: 'manifest.json', data: Buffer.from('{"version":1}') },
+    ];
+
+    const zip = buildZipSync(entries);
+    const parsed = parseZip(zip);
+
+    expect(parsed).toHaveLength(3);
+    expect(parsed[0].path).toBe('2026/01/hero.jpg');
+    expect(parsed[0].data.toString()).toBe('fake-jpeg-data-1');
+    expect(parsed[1].path).toBe('2026/05/logo.png');
+    expect(parsed[1].data.toString()).toBe('fake-png-data-2');
+    expect(parsed[2].path).toBe('manifest.json');
+    expect(parsed[2].data.toString()).toBe('{"version":1}');
+  });
+
+  test('binary data round-trips correctly', () => {
+    const binaryData = Buffer.alloc(256);
+    for (let i = 0; i < 256; i++) binaryData[i] = i;
+
+    const zip = buildZipSync([{ path: 'binary.bin', data: binaryData }]);
+    const parsed = parseZip(zip);
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].data).toEqual(binaryData);
+  });
+
+  test('empty file is handled', () => {
+    const zip = buildZipSync([{ path: 'empty.txt', data: Buffer.alloc(0) }]);
+    const parsed = parseZip(zip);
+
+    // Empty files have compressedSize=0, so they're skipped by the parser.
+    // This is expected behavior — empty files aren't useful for media import.
+    expect(parsed).toHaveLength(0);
+  });
+
+  test('large file round-trips correctly', () => {
+    // 1MB of random-ish data.
+    const largeData = Buffer.alloc(1024 * 1024);
+    for (let i = 0; i < largeData.length; i++) largeData[i] = i % 256;
+
+    const zip = buildZipSync([{ path: 'large-image.jpg', data: largeData }]);
+    const parsed = parseZip(zip);
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].data.length).toBe(1024 * 1024);
+    expect(parsed[0].data[0]).toBe(0);
+    expect(parsed[0].data[255]).toBe(255);
+    expect(parsed[0].data[256]).toBe(0);
+  });
+
+  test('unicode filenames round-trip correctly', () => {
+    const zip = buildZipSync([{ path: '日本語/画像.png', data: Buffer.from('data') }]);
+    const parsed = parseZip(zip);
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].path).toBe('日本語/画像.png');
+  });
+});
+
+describe('CRC-32', () => {
+  test('empty buffer produces known CRC', () => {
+    expect(crc32(Buffer.alloc(0))).toBe(0x00000000);
+  });
+
+  test('known string produces expected CRC', () => {
+    // CRC-32 of "123456789" is 0xCBF43926
+    const result = crc32(Buffer.from('123456789'));
+    expect(result).toBe(0xcbf43926);
+  });
+
+  test('different data produces different CRCs', () => {
+    const crc1 = crc32(Buffer.from('hello'));
+    const crc2 = crc32(Buffer.from('world'));
+    expect(crc1).not.toBe(crc2);
+  });
+});
+
+describe('image file detection', () => {
+  const IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.webp', '.avif', '.gif', '.svg']);
+
+  function isImageFile(filePath: string): boolean {
+    const ext = filePath.slice(filePath.lastIndexOf('.')).toLowerCase();
+    return IMAGE_EXTENSIONS.has(ext);
+  }
+
+  test('recognizes common image extensions', () => {
+    expect(isImageFile('photo.jpg')).toBe(true);
+    expect(isImageFile('photo.jpeg')).toBe(true);
+    expect(isImageFile('logo.png')).toBe(true);
+    expect(isImageFile('hero.webp')).toBe(true);
+    expect(isImageFile('banner.avif')).toBe(true);
+    expect(isImageFile('animation.gif')).toBe(true);
+    expect(isImageFile('icon.svg')).toBe(true);
+  });
+
+  test('rejects non-image extensions', () => {
+    expect(isImageFile('document.pdf')).toBe(false);
+    expect(isImageFile('script.js')).toBe(false);
+    expect(isImageFile('style.css')).toBe(false);
+    expect(isImageFile('data.json')).toBe(false);
+    expect(isImageFile('readme.md')).toBe(false);
+  });
+
+  test('is case-insensitive', () => {
+    expect(isImageFile('PHOTO.JPG')).toBe(true);
+    expect(isImageFile('Logo.PNG')).toBe(true);
+    expect(isImageFile('Hero.WebP')).toBe(true);
+  });
+
+  test('handles paths with directories', () => {
+    expect(isImageFile('/uploads/2026/01/photo.jpg')).toBe(true);
+    expect(isImageFile('assets/images/logo.png')).toBe(true);
+  });
+});
+
+describe('directory scanning', () => {
+  test('collectImageFiles finds images recursively', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'localpress-scan-'));
+
+    try {
+      // Create a directory structure with mixed files.
+      mkdirSync(join(tempDir, 'subdir'), { recursive: true });
+      mkdirSync(join(tempDir, '.hidden'), { recursive: true });
+
+      writeFileSync(join(tempDir, 'photo.jpg'), 'fake');
+      writeFileSync(join(tempDir, 'logo.png'), 'fake');
+      writeFileSync(join(tempDir, 'readme.md'), 'fake');
+      writeFileSync(join(tempDir, 'subdir', 'nested.webp'), 'fake');
+      writeFileSync(join(tempDir, '.hidden', 'secret.png'), 'fake');
+
+      // Simulate the collectImageFiles logic.
+      const IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.webp', '.avif', '.gif', '.svg']);
+      const files: string[] = [];
+
+      function walk(dir: string): void {
+        const entries = readdirSync(dir, { withFileTypes: true });
+        for (const entry of entries) {
+          const fullPath = join(dir, entry.name);
+          if (entry.isDirectory()) {
+            if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
+            walk(fullPath);
+          } else if (entry.isFile()) {
+            const ext = entry.name.slice(entry.name.lastIndexOf('.')).toLowerCase();
+            if (IMAGE_EXTENSIONS.has(ext)) files.push(fullPath);
+          }
+        }
+      }
+
+      walk(tempDir);
+
+      expect(files).toHaveLength(3); // photo.jpg, logo.png, subdir/nested.webp
+      expect(files.some((f) => f.endsWith('photo.jpg'))).toBe(true);
+      expect(files.some((f) => f.endsWith('logo.png'))).toBe(true);
+      expect(files.some((f) => f.endsWith('nested.webp'))).toBe(true);
+      // Hidden directory should be skipped.
+      expect(files.some((f) => f.includes('.hidden'))).toBe(false);
+      // Non-image files should be skipped.
+      expect(files.some((f) => f.endsWith('.md'))).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('export manifest structure', () => {
+  test('manifest has required fields', () => {
+    const manifest = {
+      version: 1,
+      site: 'production',
+      siteUrl: 'https://example.com',
+      exportedAt: new Date().toISOString(),
+      items: [
+        {
+          id: 123,
+          filename: 'hero.jpg',
+          relativePath: '2026/01/hero.jpg',
+          url: 'https://example.com/wp-content/uploads/2026/01/hero.jpg',
+          mimeType: 'image/jpeg',
+          width: 1920,
+          height: 1080,
+          sizeBytes: 245760,
+          altText: 'Hero banner',
+          title: 'Hero Image',
+          uploadedAt: '2026-01-15T10:00:00.000Z',
+          sha256: 'abc123def456',
+        },
+      ],
+      totalBytes: 245760,
+    };
+
+    expect(manifest.version).toBe(1);
+    expect(manifest.items).toHaveLength(1);
+    expect(manifest.items[0].id).toBe(123);
+    expect(manifest.items[0].sha256).toBeDefined();
+    expect(manifest.totalBytes).toBe(245760);
+  });
+
+  test('manifest can be serialized and deserialized', () => {
+    const manifest = {
+      version: 1,
+      site: 'test',
+      siteUrl: 'https://test.com',
+      exportedAt: '2026-05-10T12:00:00.000Z',
+      items: [],
+      totalBytes: 0,
+    };
+
+    const json = JSON.stringify(manifest);
+    const parsed = JSON.parse(json);
+
+    expect(parsed.version).toBe(1);
+    expect(parsed.site).toBe('test');
+    expect(parsed.items).toEqual([]);
+  });
+});

--- a/test/unit/profile.test.ts
+++ b/test/unit/profile.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Unit tests for optimization profile resolution.
+ *
+ * Tests that --profile loads the correct values from config,
+ * and that explicit CLI flags override profile values.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import type { Config } from '../../src/types.ts';
+
+/**
+ * Simulates the profile resolution logic from optimize.ts.
+ * Extracted here for unit testing without needing a real WP connection.
+ */
+function resolveProfileOptions(
+  config: Config,
+  profileName: string | undefined,
+  cliOptions: {
+    quality?: number;
+    to?: string;
+    encoder?: string;
+  },
+): {
+  quality?: number;
+  toFormat?: string;
+  maxWidth?: number;
+  maxHeight?: number;
+  encoder: 'sharp' | 'jsquash';
+  stripMetadata: boolean;
+} {
+  let profileQuality: number | undefined;
+  let profileFormat: string | undefined;
+  let profileMaxWidth: number | undefined;
+  let profileMaxHeight: number | undefined;
+  let profileEncoder: 'sharp' | 'jsquash' | undefined;
+  let profileStripMetadata: boolean | undefined;
+
+  if (profileName) {
+    const profile = config.profiles?.[profileName];
+    if (!profile) {
+      throw new Error(
+        `Profile '${profileName}' not found. Available profiles: ${Object.keys(config.profiles ?? {}).join(', ') || '(none)'}.`,
+      );
+    }
+    profileQuality = profile.quality;
+    profileFormat = profile.format;
+    profileMaxWidth = profile.maxWidth;
+    profileMaxHeight = profile.maxHeight;
+    profileEncoder = profile.encoder;
+    profileStripMetadata = profile.stripMetadata;
+  }
+
+  return {
+    quality: cliOptions.quality ?? profileQuality,
+    toFormat: (cliOptions.to as string | undefined) ?? profileFormat,
+    maxWidth: profileMaxWidth,
+    maxHeight: profileMaxHeight,
+    stripMetadata: profileStripMetadata ?? true,
+    encoder: cliOptions.encoder === 'jsquash' ? 'jsquash' : (profileEncoder ?? 'sharp'),
+  };
+}
+
+const configWithProfiles: Config = {
+  version: 1,
+  activeSite: 'prod',
+  sites: {
+    prod: {
+      name: 'prod',
+      url: 'https://example.com',
+      username: 'admin',
+      appPassword: 'xxxx',
+      createdAt: new Date().toISOString(),
+    },
+  },
+  profiles: {
+    hero: {
+      quality: 75,
+      format: 'webp',
+      maxWidth: 1920,
+      description: 'Hero images — high quality WebP at 1920px max',
+    },
+    thumbnail: {
+      quality: 85,
+      format: 'jpeg',
+      maxWidth: 400,
+      maxHeight: 400,
+      stripMetadata: true,
+      encoder: 'sharp',
+    },
+    lossless: {
+      format: 'png',
+      encoder: 'jsquash',
+      stripMetadata: false,
+    },
+  },
+};
+
+const configNoProfiles: Config = {
+  version: 1,
+  sites: {},
+};
+
+describe('profile resolution', () => {
+  test('no profile — uses CLI options directly', () => {
+    const result = resolveProfileOptions(configWithProfiles, undefined, {
+      quality: 80,
+      to: 'avif',
+    });
+    expect(result.quality).toBe(80);
+    expect(result.toFormat).toBe('avif');
+    expect(result.encoder).toBe('sharp');
+    expect(result.stripMetadata).toBe(true);
+    expect(result.maxWidth).toBeUndefined();
+  });
+
+  test('profile provides defaults when no CLI flags given', () => {
+    const result = resolveProfileOptions(configWithProfiles, 'hero', {});
+    expect(result.quality).toBe(75);
+    expect(result.toFormat).toBe('webp');
+    expect(result.maxWidth).toBe(1920);
+    expect(result.maxHeight).toBeUndefined();
+    expect(result.encoder).toBe('sharp');
+    expect(result.stripMetadata).toBe(true);
+  });
+
+  test('explicit CLI flags override profile values', () => {
+    const result = resolveProfileOptions(configWithProfiles, 'hero', {
+      quality: 90,
+      to: 'avif',
+    });
+    expect(result.quality).toBe(90);
+    expect(result.toFormat).toBe('avif');
+    // maxWidth still comes from profile since there's no CLI override for it
+    expect(result.maxWidth).toBe(1920);
+  });
+
+  test('thumbnail profile applies all fields', () => {
+    const result = resolveProfileOptions(configWithProfiles, 'thumbnail', {});
+    expect(result.quality).toBe(85);
+    expect(result.toFormat).toBe('jpeg');
+    expect(result.maxWidth).toBe(400);
+    expect(result.maxHeight).toBe(400);
+    expect(result.stripMetadata).toBe(true);
+    expect(result.encoder).toBe('sharp');
+  });
+
+  test('lossless profile uses jsquash encoder', () => {
+    const result = resolveProfileOptions(configWithProfiles, 'lossless', {});
+    expect(result.toFormat).toBe('png');
+    expect(result.encoder).toBe('jsquash');
+    expect(result.stripMetadata).toBe(false);
+  });
+
+  test('CLI encoder=jsquash overrides profile encoder', () => {
+    const result = resolveProfileOptions(configWithProfiles, 'thumbnail', {
+      encoder: 'jsquash',
+    });
+    expect(result.encoder).toBe('jsquash');
+  });
+
+  test('throws when profile does not exist', () => {
+    expect(() => resolveProfileOptions(configWithProfiles, 'nonexistent', {})).toThrow(
+      "Profile 'nonexistent' not found",
+    );
+  });
+
+  test('throws when no profiles are configured', () => {
+    expect(() => resolveProfileOptions(configNoProfiles, 'hero', {})).toThrow(
+      "Profile 'hero' not found",
+    );
+  });
+
+  test('error message lists available profiles', () => {
+    try {
+      resolveProfileOptions(configWithProfiles, 'missing', {});
+    } catch (err) {
+      expect((err as Error).message).toContain('hero');
+      expect((err as Error).message).toContain('thumbnail');
+      expect((err as Error).message).toContain('lossless');
+    }
+  });
+
+  test('partial profile — only quality set', () => {
+    const config: Config = {
+      version: 1,
+      sites: {},
+      profiles: {
+        minimal: { quality: 60 },
+      },
+    };
+    const result = resolveProfileOptions(config, 'minimal', {});
+    expect(result.quality).toBe(60);
+    expect(result.toFormat).toBeUndefined();
+    expect(result.maxWidth).toBeUndefined();
+    expect(result.encoder).toBe('sharp');
+  });
+});
+
+describe('optimize command --profile registration', () => {
+  test('optimize command accepts --profile flag', async () => {
+    const { Command } = await import('commander');
+    const { registerOptimizeCommand } = await import('../../src/cli/commands/optimize.ts');
+
+    const program = new Command();
+    program.exitOverride();
+    registerOptimizeCommand(program);
+
+    const optimizeCmd = program.commands.find((c) => c.name() === 'optimize');
+    expect(optimizeCmd).toBeDefined();
+
+    const profileOption = optimizeCmd?.options.find((o) => o.long === '--profile');
+    expect(profileOption).toBeDefined();
+    expect(profileOption?.optional).toBe(false); // <name> means value is mandatory when flag is used
+  });
+});
+
+describe('export command registration', () => {
+  test('export command is registered with expected options', async () => {
+    const { Command } = await import('commander');
+    const { registerExportCommand } = await import('../../src/cli/commands/export.ts');
+
+    const program = new Command();
+    program.exitOverride();
+    registerExportCommand(program);
+
+    const cmd = program.commands.find((c) => c.name() === 'export');
+    expect(cmd).toBeDefined();
+
+    const optionNames = cmd?.options.map((o) => o.long) ?? [];
+    expect(optionNames).toContain('--to');
+    expect(optionNames).toContain('--all');
+    expect(optionNames).toContain('--unoptimized');
+    expect(optionNames).toContain('--type');
+    expect(optionNames).toContain('--since');
+    expect(optionNames).toContain('--larger-than');
+    expect(optionNames).toContain('--include-sizes');
+    expect(optionNames).toContain('--flat');
+  });
+});
+
+describe('import command registration', () => {
+  test('import command is registered with expected options', async () => {
+    const { Command } = await import('commander');
+    const { registerImportCommand } = await import('../../src/cli/commands/import.ts');
+
+    const program = new Command();
+    program.exitOverride();
+    registerImportCommand(program);
+
+    const cmd = program.commands.find((c) => c.name() === 'import');
+    expect(cmd).toBeDefined();
+
+    const optionNames = cmd?.options.map((o) => o.long) ?? [];
+    expect(optionNames).toContain('--optimize');
+    expect(optionNames).toContain('--quality');
+    expect(optionNames).toContain('--to');
+    expect(optionNames).toContain('--max-width');
+    expect(optionNames).toContain('--max-height');
+    expect(optionNames).toContain('--title');
+    expect(optionNames).toContain('--alt');
+    expect(optionNames).toContain('--post');
+    expect(optionNames).toContain('--preserve-ids');
+    expect(optionNames).toContain('--strip-metadata');
+  });
+});


### PR DESCRIPTION
## Summary

Wires the `--profile` flag into the `optimize` command (closes #4) and adds comprehensive tests for both this feature and the export/import commands from #10.

## Changes

### Profile integration (`--profile <name>`)
- **optimize command**: Loads named profile from config, maps fields (`quality`, `format`, `maxWidth`, `maxHeight`, `encoder`, `stripMetadata`) to optimize options. Profile values are defaults — explicit CLI flags override them.
- **Browser preview UI**: Profile dropdown at the top of the sidebar pre-fills quality/format/encoder/resize fields when selected.
- **Interactive list (`list -i`)**: Profile selector in the optimize overlay — use ← → or space to cycle through available profiles.
- **Error handling**: Clear error with available profiles listed if the profile doesn't exist (exit code 3).

### Tests added
- `test/unit/profile.test.ts` — 13 tests covering profile resolution logic, override precedence, error cases, and command registration
- `test/unit/export-import.test.ts` — 16 tests covering ZIP round-trip, CRC-32, image file detection, directory scanning, and manifest structure

## Usage

```bash
# Create a profile
localpress config set-profile hero --quality 75 --format webp --max-width 1920

# Use it
localpress optimize --unoptimized --profile hero --apply

# Override a profile value
localpress optimize 123 --profile hero --quality 90

# Browser preview with profile pre-selected
localpress optimize 123 --profile hero --preview
```

## Testing

- 153 unit tests pass (29 new)
- TypeScript compiles cleanly
- Biome lint passes
