### PR TITLE
feat(mcp): first-party MCP server (v1.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-05-11
+
+### Added
+- **`localpress mcp` command**: first-party Model Context Protocol server.
+  Spawned by an MCP host (Claude Desktop, Cursor, Claude Code, etc.) as a
+  stdio child process, exposing 20 tools and 3 resources for agentic workflows.
+  Same binary, new entrypoint — no daemon, no hosting, no separate config.
+- **20 MCP tools** covering setup (`sites_*`, `doctor`, `config_*`), discovery
+  (`list`, `show`, `stats`, `audit`, `references`), processing (`optimize`,
+  `convert`, `resize`, `remove_bg`, `caption`), and library ops (`pull`, `push`,
+  `regenerate`, `export`, `import`). Every tool accepts an optional `site` arg;
+  when omitted, the active site from config is used.
+- **3 MCP resources** for read-only context: `localpress://sites`,
+  `localpress://stats`, `localpress://capabilities`.
+- **`@modelcontextprotocol/sdk` dep** (v1.29) — lazy-loaded so CLI startup time
+  is unaffected when not running as an MCP server.
+- **Round-trip MCP tests** (`test/unit/mcp.test.ts`): boots the server as a
+  real subprocess via the SDK's client, asserts on the protocol-level
+  responses (listTools, listResources, callTool, input schemas).
+
+### Notes
+- Bulk-op tools (`optimize`, `convert`, `resize`, `caption`, etc.) preserve
+  the CLI's safe-by-default behavior: passing `unoptimized: true` or
+  `all: true` dry-runs unless `apply: true` is also set.
+- Interactive commands (`edit`, `watch`, `init`, `update`, `completions`) are
+  intentionally not exposed — they require TTY and aren't meaningful in an
+  agentic context. Use the CLI directly for those.
+- Tools dispatch by spawning the same `localpress` binary recursively with
+  `--json --quiet`. This reuses the CLI's stable JSON contract, so every
+  existing CLI feature appears in the MCP server with zero per-tool engine
+  code. Hot paths can migrate to in-process dispatch later without breaking
+  schemas.
+
 ## [1.13.1] - 2026-05-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -229,14 +229,23 @@ The CLI talks to WordPress through a **backend adapter** that auto-detects what'
 
 ## AI agent integration
 
-The `skill/SKILL.md` file is a complete instruction sheet for AI agents (Claude Desktop, Cursor, VS Code with MCP, etc.). It covers:
+Two ways to drive localpress from an agent:
 
-- When to invoke localpress vs. the user's existing WP MCP server
-- Full command reference with `--json` output schemas
-- Composition patterns for mixed WP MCP + localpress workflows
-- Error codes and handling guidance
+**1. MCP server (recommended)** — `localpress mcp` is a stdio Model Context Protocol server that exposes 20 typed tools and 3 resources. Add it to any MCP host (Claude Desktop, Cursor, Claude Code, VS Code) with a one-line config:
 
-Always pass `--json` when running from an agent — the human-readable output is not designed for parsing.
+```jsonc
+{
+  "mcpServers": {
+    "localpress": { "command": "localpress", "args": ["mcp"] }
+  }
+}
+```
+
+The agent gets typed schemas for every operation, structured results, and capability discovery via the `localpress://capabilities` resource. See [`.wiki/MCP-Setup.md`](.wiki/MCP-Setup.md) for full setup instructions per host.
+
+**2. Markdown skill** — `skill/SKILL.md` is a complete instruction sheet for agents that prefer shelling out to the CLI directly. Works in any agent that can run bash.
+
+Always pass `--json` when running the CLI from an agent — the human-readable output is not designed for parsing.
 
 ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@jsquash/png": "^3.1.1",
         "@jsquash/resize": "^2.1.1",
         "@jsquash/webp": "^1.5.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "chokidar": "^3.6.0",
         "commander": "^12.1.0",
         "ink": "^5.0.1",
@@ -18,6 +19,7 @@
         "pino": "^9.5.0",
         "react": "^18.3.1",
         "sharp": "^0.33.5",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
@@ -50,6 +52,8 @@
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
 
@@ -101,6 +105,8 @@
 
     "@jsquash/webp": ["@jsquash/webp@1.5.0", "", { "dependencies": { "wasm-feature-detect": "^1.2.11" } }, "sha512-KggLoj2MnRSfIqTeKe1EmbljTX2vuV7mh79k89PCL1pyqiDULcPM1L47twxXt0hkb68F70bXiL31MxsuoZtKFw=="],
 
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
@@ -109,7 +115,13 @@
 
     "@types/react": ["@types/react@18.3.28", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
@@ -125,9 +137,17 @@
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -151,17 +171,39 @@
 
     "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
@@ -169,15 +211,45 @@
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
     "es-toolkit": ["es-toolkit@1.46.1", "", {}, "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.1", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -189,9 +261,25 @@
 
     "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
 
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
 
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
     "ink": ["ink@5.2.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.1.3", "ansi-escapes": "^7.0.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^4.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.22.0", "indent-string": "^5.0.0", "is-in-ci": "^1.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.29.0", "scheduler": "^0.23.0", "signal-exit": "^3.0.7", "slice-ansi": "^7.1.0", "stack-utils": "^2.0.6", "string-width": "^7.2.0", "type-fest": "^4.27.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=18.0.0", "react": ">=18.0.0", "react-devtools-core": "^4.19.1" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-arrayish": ["is-arrayish@0.3.4", "", {}, "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="],
 
@@ -207,19 +295,51 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
     "matcher": ["matcher@4.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-S6x5wmcDmsDRRU/c2dkccDwQPXoFczc5+HpQ2lON8pnvHlnvHAHj5WlLVvw6n6vNyHuVugYrFohYxbS+pvFpKQ=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
     "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
@@ -227,7 +347,13 @@
 
     "onnxruntime-node": ["onnxruntime-node@1.25.1", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^4.1.3", "onnxruntime-common": "1.25.1" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-N0M58CGTiTsLkPpx9bxmRFi24GT6r67Qei/GrBEIiDyntcYdXU5vQZp112ypydG9vEKRFgbgUYQJnEi+jll8dg=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
@@ -237,9 +363,19 @@
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
@@ -251,19 +387,43 @@
 
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
     "serialize-error": ["serialize-error@8.1.0", "", { "dependencies": { "type-fest": "^0.20.2" } }, "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="],
 
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
@@ -277,6 +437,8 @@
 
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
 
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
@@ -285,23 +447,39 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
     "wasm-feature-detect": ["wasm-feature-detect@1.8.0", "", {}, "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
     "ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "cli-truncate/slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localpress",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "description": "Local-compute WordPress media optimization. Your laptop, your library.",
   "license": "MIT",
   "author": "Griffen Fargo",
@@ -53,13 +53,15 @@
     "@jsquash/png": "^3.1.1",
     "@jsquash/resize": "^2.1.1",
     "@jsquash/webp": "^1.5.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "chokidar": "^3.6.0",
     "commander": "^12.1.0",
     "ink": "^5.0.1",
     "onnxruntime-node": "^1.22.0",
     "pino": "^9.5.0",
     "react": "^18.3.1",
-    "sharp": "^0.33.5"
+    "sharp": "^0.33.5",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1,0 +1,24 @@
+/**
+ * `localpress mcp` — boot the MCP server over stdio.
+ *
+ * Intended to be spawned by an MCP host (Claude Desktop, Cursor, Claude Code).
+ * Talks JSON-RPC over stdin/stdout. Not designed for direct human invocation —
+ * if you run this in a terminal, nothing visible happens until JSON-RPC bytes
+ * arrive on stdin.
+ *
+ * See .wiki/MCP-Setup.md for host configuration examples.
+ */
+
+import type { Command } from 'commander';
+
+export function registerMcpCommand(program: Command): void {
+  program
+    .command('mcp')
+    .description('Run as an MCP (Model Context Protocol) server over stdio')
+    .action(async () => {
+      // Lazy-load the SDK — keeps CLI startup time unaffected when not running
+      // as an MCP server.
+      const { startMcpServer } = await import('../mcp/server.ts');
+      await startMcpServer();
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -20,6 +20,7 @@ import { registerExportCommand } from './commands/export.ts';
 import { registerImportCommand } from './commands/import.ts';
 import { registerInitCommand } from './commands/init.ts';
 import { registerListCommand } from './commands/list.ts';
+import { registerMcpCommand } from './commands/mcp.ts';
 import { registerOptimizeCommand } from './commands/optimize.ts';
 import { registerPullCommand } from './commands/pull.ts';
 import { registerPushCommand } from './commands/push.ts';
@@ -87,6 +88,7 @@ registerRegenerateCommand(program);
 registerUpdateCommand(program);
 registerWatchCommand(program);
 registerCompletionsCommand(program);
+registerMcpCommand(program);
 
 // Top-level help footer.
 program.addHelpText(

--- a/src/cli/mcp/invoke.ts
+++ b/src/cli/mcp/invoke.ts
@@ -1,0 +1,129 @@
+/**
+ * Spawn the localpress CLI from inside the MCP server and capture its --json output.
+ *
+ * Every MCP tool is a thin wrapper around the existing CLI: we build the argv,
+ * spawn the same binary recursively, parse stdout as JSON, and return a
+ * structured result. This reuses the CLI's stable JSON contract (which the
+ * skill already depends on) and means every CLI feature appears in the MCP
+ * server for free.
+ *
+ * Long-running ops can't stream progress this way — we get the final JSON
+ * blob only. That's acceptable for v1.14; hot paths can move to in-process
+ * dispatch later without changing the tool schemas.
+ */
+
+import { spawn } from 'node:child_process';
+import { getSelfBin, isDevMode } from '../utils/self-invoke.ts';
+
+export interface CliResult {
+  /** Exit code from the child process. */
+  exitCode: number;
+  /** Parsed JSON output from stdout, or the raw text if parsing failed. */
+  stdout: unknown;
+  /** Raw stderr text — collected for error reporting. */
+  stderr: string;
+  /** True if exitCode === 0. */
+  ok: boolean;
+}
+
+export interface InvokeOptions {
+  /** Override site for this call. Maps to `--site <name>`. */
+  site?: string;
+  /** Subcommand and its args, e.g. `['list', '--unoptimized']`. */
+  args: string[];
+  /** Working directory for the child process. */
+  cwd?: string;
+  /** Timeout in ms; child is killed if exceeded. Default: 5 minutes. */
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+
+export async function invokeCli(opts: InvokeOptions): Promise<CliResult> {
+  const bin = getSelfBin(process.argv, process.execPath);
+  const baseArgs = [...opts.args];
+
+  // Always force JSON output for MCP tools.
+  if (!baseArgs.includes('--json')) baseArgs.push('--json');
+  // Suppress info-level chatter; we only want the JSON record.
+  if (!baseArgs.includes('--quiet')) baseArgs.push('--quiet');
+
+  // Inject --site if provided. CLI accepts --site at the top level.
+  const argsWithSite = opts.site ? ['--site', opts.site, ...baseArgs] : baseArgs;
+
+  // In dev mode (`bun src/cli/index.ts mcp`), we need to re-invoke with the
+  // script path as the first arg so bun knows what to run. In prod (compiled
+  // binary or wrapper), the binary is the entrypoint and args go directly.
+  const childArgs = isDevMode(process.argv, process.execPath)
+    ? [process.argv[1], ...argsWithSite]
+    : argsWithSite;
+
+  return await new Promise<CliResult>((resolve) => {
+    const child = spawn(bin, childArgs, {
+      cwd: opts.cwd ?? process.cwd(),
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdoutBuf = '';
+    let stderrBuf = '';
+    let timedOut = false;
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+    }, opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+    child.stdout.on('data', (chunk) => {
+      stdoutBuf += chunk.toString('utf8');
+    });
+    child.stderr.on('data', (chunk) => {
+      stderrBuf += chunk.toString('utf8');
+    });
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      resolve({
+        exitCode: -1,
+        stdout: null,
+        stderr: `${stderrBuf}${err.message}`,
+        ok: false,
+      });
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      const exitCode = code ?? -1;
+      let parsed: unknown = stdoutBuf;
+
+      const trimmed = stdoutBuf.trim();
+      if (trimmed.length > 0) {
+        try {
+          parsed = JSON.parse(trimmed);
+        } catch {
+          // Some commands emit NDJSON (one record per line). Try line-by-line.
+          const lines = trimmed.split('\n').filter(Boolean);
+          if (lines.length > 1) {
+            try {
+              parsed = lines.map((l) => JSON.parse(l));
+            } catch {
+              // Fall back to raw text.
+              parsed = trimmed;
+            }
+          } else {
+            parsed = trimmed;
+          }
+        }
+      }
+
+      resolve({
+        exitCode,
+        stdout: parsed,
+        stderr: timedOut
+          ? `${stderrBuf}\n[timed out after ${opts.timeoutMs ?? DEFAULT_TIMEOUT_MS}ms]`
+          : stderrBuf,
+        ok: exitCode === 0,
+      });
+    });
+  });
+}

--- a/src/cli/mcp/resources.ts
+++ b/src/cli/mcp/resources.ts
@@ -1,0 +1,66 @@
+/**
+ * MCP resources for localpress.
+ *
+ * Resources surface read-only context an agent might want to load proactively,
+ * without having to call a tool. Three resources today:
+ *
+ *   localpress://sites         — configured sites + active site marker
+ *   localpress://stats         — cumulative processing stats for the active site
+ *   localpress://capabilities  — backend capability matrix for the active site
+ *
+ * All three dispatch through the CLI's --json contract via invokeCli().
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { invokeCli } from './invoke.ts';
+
+async function readAsResource(uri: URL, args: string[]) {
+  const result = await invokeCli({ args });
+  const body =
+    typeof result.stdout === 'string' ? result.stdout : JSON.stringify(result.stdout, null, 2);
+  return {
+    contents: [
+      {
+        uri: uri.href,
+        mimeType: 'application/json',
+        text: result.ok ? body : `Error (exit ${result.exitCode}):\n${result.stderr}\n\n${body}`,
+      },
+    ],
+  };
+}
+
+export function registerResources(server: McpServer): void {
+  server.registerResource(
+    'sites',
+    'localpress://sites',
+    {
+      title: 'Configured sites',
+      description: 'All WordPress sites configured for localpress, with the active site marked.',
+      mimeType: 'application/json',
+    },
+    async (uri) => readAsResource(uri, ['sites']),
+  );
+
+  server.registerResource(
+    'stats',
+    'localpress://stats',
+    {
+      title: 'Active site stats',
+      description: 'Cumulative processing stats and library health for the active site.',
+      mimeType: 'application/json',
+    },
+    async (uri) => readAsResource(uri, ['stats']),
+  );
+
+  server.registerResource(
+    'capabilities',
+    'localpress://capabilities',
+    {
+      title: 'Backend capabilities',
+      description:
+        'Capability matrix for the active site: which adapters are available, what each can do.',
+      mimeType: 'application/json',
+    },
+    async (uri) => readAsResource(uri, ['doctor']),
+  );
+}

--- a/src/cli/mcp/server.ts
+++ b/src/cli/mcp/server.ts
@@ -1,0 +1,44 @@
+/**
+ * Boot the localpress MCP server over stdio.
+ *
+ * Spawned as a long-lived child process by an MCP host (Claude Desktop,
+ * Cursor, Claude Code, etc.). Talks JSON-RPC over stdin/stdout.
+ *
+ * Implementation: each registered tool dispatches by spawning the same
+ * localpress binary recursively with `--json --quiet` (see invoke.ts).
+ * This reuses the CLI's stable JSON contract and means every CLI feature
+ * appears in the MCP server for free.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import packageJson from '../../../package.json' with { type: 'json' };
+import { registerResources } from './resources.ts';
+import { registerTools } from './tools.ts';
+
+export async function startMcpServer(): Promise<void> {
+  const server = new McpServer(
+    {
+      name: 'localpress',
+      version: packageJson.version,
+    },
+    {
+      capabilities: {
+        tools: {},
+        resources: {},
+      },
+      instructions:
+        "localpress is a CLI for local-compute WordPress media optimization. Tools call the local CLI, which talks to the user's configured WordPress site via REST + Application Passwords (and optionally WP-CLI over SSH). Every tool accepts an optional `site` arg; when omitted, the active site from config is used. Bulk ops (list+optimize/convert/resize/caption with --unoptimized or --all) are dry-run by default — pass `apply: true` to execute.",
+    },
+  );
+
+  registerTools(server);
+  registerResources(server);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  // The connect() call returns once the transport is wired up. The process
+  // stays alive because stdin is open. When the host closes stdin, the
+  // transport closes and Node exits naturally.
+}

--- a/src/cli/mcp/tools.ts
+++ b/src/cli/mcp/tools.ts
@@ -1,0 +1,697 @@
+/**
+ * MCP tool definitions for localpress.
+ *
+ * Each tool maps to one CLI command. The schema describes the JSON shape the
+ * agent sends; we translate that into CLI argv and invoke the same binary
+ * recursively (see `invoke.ts`).
+ *
+ * Schema philosophy: keep input args close to the CLI flag names so the
+ * skill/docs remain a single source of truth. Camel-case in the JSON,
+ * kebab-case on the wire.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { invokeCli } from './invoke.ts';
+
+/**
+ * Common args every tool accepts.
+ * `site` is optional — when omitted, the CLI uses the active site from config.
+ */
+const commonSiteArg = {
+  site: z
+    .string()
+    .optional()
+    .describe(
+      'Override the active site for this call. When omitted, uses the active site from config.',
+    ),
+};
+
+type ArgMap = Record<string, unknown>;
+
+/** Push a boolean flag onto argv if truthy. */
+function flag(argv: string[], name: string, value: unknown): void {
+  if (value === true) argv.push(name);
+}
+
+/** Push `--name <value>` onto argv if value is defined. */
+function opt(argv: string[], name: string, value: unknown): void {
+  if (value === undefined || value === null || value === '') return;
+  argv.push(name, String(value));
+}
+
+/** Push positional IDs onto argv. */
+function ids(argv: string[], value: unknown): void {
+  if (Array.isArray(value)) {
+    for (const id of value) argv.push(String(id));
+  } else if (typeof value === 'number' || typeof value === 'string') {
+    argv.push(String(value));
+  }
+}
+
+/** Run a CLI command and shape the response for MCP. */
+async function runCli(args: string[], site?: string) {
+  const result = await invokeCli({ args, site });
+  if (!result.ok) {
+    return {
+      isError: true as const,
+      content: [
+        {
+          type: 'text' as const,
+          text:
+            typeof result.stdout === 'string'
+              ? `${result.stderr || result.stdout || 'CLI exited with error'} (exit ${result.exitCode})`
+              : `${result.stderr || 'CLI exited with error'} (exit ${result.exitCode})\n\n${JSON.stringify(result.stdout, null, 2)}`,
+        },
+      ],
+    };
+  }
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text:
+          typeof result.stdout === 'string'
+            ? result.stdout
+            : JSON.stringify(result.stdout, null, 2),
+      },
+    ],
+    structuredContent:
+      typeof result.stdout === 'object' && result.stdout !== null
+        ? (result.stdout as Record<string, unknown>)
+        : undefined,
+  };
+}
+
+export function registerTools(server: McpServer): void {
+  // ---------------------------------------------------------------------------
+  // Setup & configuration
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    'sites_list',
+    {
+      title: 'List configured sites',
+      description:
+        'List all WordPress sites configured for localpress, with the active one marked.',
+      inputSchema: {},
+    },
+    async () => runCli(['sites']),
+  );
+
+  server.registerTool(
+    'sites_use',
+    {
+      title: 'Switch active site',
+      description: 'Make the named site the active one for subsequent operations.',
+      inputSchema: {
+        name: z.string().describe('Name of the site to activate. Must match one from sites_list.'),
+      },
+    },
+    async ({ name }) => runCli(['sites', 'use', name as string]),
+  );
+
+  server.registerTool(
+    'sites_add',
+    {
+      title: 'Add a WordPress site',
+      description:
+        'Register a new WordPress site non-interactively. Requires an Application Password.',
+      inputSchema: {
+        url: z.string().describe('Site URL (https://example.com)'),
+        username: z.string().describe('WordPress username'),
+        appPassword: z.string().describe('WordPress Application Password'),
+        name: z.string().optional().describe('Site name (defaults to hostname)'),
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      const argv = ['sites', 'add', a.url as string];
+      opt(argv, '--username', a.username);
+      opt(argv, '--app-password', a.appPassword);
+      opt(argv, '--name', a.name);
+      return runCli(argv);
+    },
+  );
+
+  server.registerTool(
+    'sites_remove',
+    {
+      title: 'Remove a site',
+      description:
+        'Remove a configured site and its local SQLite database. Does not touch WordPress.',
+      inputSchema: {
+        name: z.string().describe('Site name to remove'),
+      },
+    },
+    async ({ name }) => runCli(['sites', 'remove', name as string]),
+  );
+
+  server.registerTool(
+    'doctor',
+    {
+      title: 'Show backend capabilities',
+      description:
+        'Report which adapters (REST, WP-CLI) are available, which capabilities each provides, and any detected issues.',
+      inputSchema: {
+        ...commonSiteArg,
+        allSites: z.boolean().optional().describe('Show capabilities for every configured site'),
+        plugins: z.boolean().optional().describe('Probe for relevant WordPress plugins'),
+        fix: z.boolean().optional().describe('Attempt auto-remediation of detected issues'),
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      const argv = ['doctor'];
+      flag(argv, '--all-sites', a.allSites);
+      flag(argv, '--plugins', a.plugins);
+      flag(argv, '--fix', a.fix);
+      return runCli(argv, a.site as string | undefined);
+    },
+  );
+
+  server.registerTool(
+    'config_get',
+    {
+      title: 'Read a config value',
+      description: 'Read a single config value by dotted key (e.g. `defaults.quality`).',
+      inputSchema: {
+        key: z.string().describe('Dotted config key, e.g. `defaults.quality` or `activeSite`'),
+      },
+    },
+    async ({ key }) => runCli(['config', 'get', key as string]),
+  );
+
+  server.registerTool(
+    'config_set',
+    {
+      title: 'Write a config value',
+      description:
+        'Set a config value by dotted key. Use sparingly — credentials should be added via sites_add.',
+      inputSchema: {
+        key: z.string().describe('Dotted config key'),
+        value: z.string().describe('New value (will be parsed as JSON when possible)'),
+      },
+    },
+    async ({ key, value }) => runCli(['config', 'set', key as string, value as string]),
+  );
+
+  server.registerTool(
+    'config_list_profiles',
+    {
+      title: 'List optimization profiles',
+      description: 'List all named optimization profiles defined in config.',
+      inputSchema: {},
+    },
+    async () => runCli(['config', 'list-profiles']),
+  );
+
+  server.registerTool(
+    'config_get_profile',
+    {
+      title: 'Get a named profile',
+      description: 'Read the settings for a single named optimization profile.',
+      inputSchema: {
+        name: z.string().describe('Profile name'),
+      },
+    },
+    async ({ name }) => runCli(['config', 'get-profile', name as string]),
+  );
+
+  server.registerTool(
+    'config_set_profile',
+    {
+      title: 'Create or update a profile',
+      description: 'Create or update a reusable optimization profile.',
+      inputSchema: {
+        name: z.string().describe('Profile name'),
+        quality: z.number().int().min(1).max(100).optional(),
+        format: z.enum(['webp', 'avif', 'jpeg', 'png']).optional(),
+        maxWidth: z.number().int().positive().optional(),
+        maxHeight: z.number().int().positive().optional(),
+        encoder: z.enum(['sharp', 'jsquash']).optional(),
+        stripMetadata: z.boolean().optional(),
+        description: z.string().optional(),
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      const argv = ['config', 'set-profile', a.name as string];
+      opt(argv, '--quality', a.quality);
+      opt(argv, '--format', a.format);
+      opt(argv, '--max-width', a.maxWidth);
+      opt(argv, '--max-height', a.maxHeight);
+      opt(argv, '--encoder', a.encoder);
+      flag(argv, '--strip-metadata', a.stripMetadata);
+      opt(argv, '--description', a.description);
+      return runCli(argv);
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Discovery
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    'list',
+    {
+      title: 'List media items',
+      description:
+        "List media in the active site's library. Filters compose: unoptimized, type, size, post association, date range.",
+      inputSchema: {
+        ...commonSiteArg,
+        unoptimized: z.boolean().optional().describe("Only items localpress hasn't processed yet"),
+        type: z.string().optional().describe('MIME type filter (e.g. image/jpeg)'),
+        post: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe('Attachments associated with a specific post'),
+        since: z.string().optional().describe('ISO date — only items uploaded since this date'),
+        largerThan: z.number().int().positive().optional().describe('Minimum size in bytes'),
+        limit: z.number().int().positive().max(100).optional().describe('Items per page'),
+        page: z.number().int().positive().optional().describe('Page number'),
+        sort: z.enum(['date', 'name', 'size', 'id']).optional(),
+        order: z.enum(['asc', 'desc']).optional(),
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      const argv = ['list'];
+      flag(argv, '--unoptimized', a.unoptimized);
+      opt(argv, '--type', a.type);
+      opt(argv, '--post', a.post);
+      opt(argv, '--since', a.since);
+      opt(argv, '--larger-than', a.largerThan);
+      opt(argv, '--limit', a.limit);
+      opt(argv, '--page', a.page);
+      opt(argv, '--sort', a.sort);
+      opt(argv, '--order', a.order);
+      return runCli(argv, a.site as string | undefined);
+    },
+  );
+
+  server.registerTool(
+    'show',
+    {
+      title: 'Show attachment details',
+      description:
+        'Fetch full details for a specific attachment, including registered sizes and processing history.',
+      inputSchema: {
+        ...commonSiteArg,
+        id: z.number().int().positive().describe('Attachment ID'),
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      return runCli(['show', String(a.id)], a.site as string | undefined);
+    },
+  );
+
+  server.registerTool(
+    'stats',
+    {
+      title: 'Cumulative processing stats',
+      description:
+        'Library health dashboard: total bytes saved, optimized %, format breakdown, recent operations.',
+      inputSchema: {
+        ...commonSiteArg,
+        allSites: z.boolean().optional().describe('Show stats for every configured site'),
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      const argv = ['stats'];
+      flag(argv, '--all-sites', a.allSites);
+      return runCli(argv, a.site as string | undefined);
+    },
+  );
+
+  server.registerTool(
+    'audit',
+    {
+      title: 'Audit the media library',
+      description:
+        'Find issues: unoptimized, oversized, missing alt text, oversized for display, duplicates, broken references, orphans.',
+      inputSchema: {
+        ...commonSiteArg,
+        unoptimized: z.boolean().optional(),
+        large: z.boolean().optional(),
+        missingAlt: z.boolean().optional(),
+        displaySize: z.boolean().optional(),
+        duplicates: z.boolean().optional(),
+        brokenRefs: z.boolean().optional(),
+        orphans: z.boolean().optional(),
+        threshold: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe('Size threshold in bytes for --large'),
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      const argv = ['audit'];
+      flag(argv, '--unoptimized', a.unoptimized);
+      flag(argv, '--large', a.large);
+      flag(argv, '--missing-alt', a.missingAlt);
+      flag(argv, '--display-size', a.displaySize);
+      flag(argv, '--duplicates', a.duplicates);
+      flag(argv, '--broken-refs', a.brokenRefs);
+      flag(argv, '--orphans', a.orphans);
+      opt(argv, '--threshold', a.threshold);
+      return runCli(argv, a.site as string | undefined);
+    },
+  );
+
+  server.registerTool(
+    'references',
+    {
+      title: 'Find references to an attachment',
+      description: 'Find every post, page, or custom-post where a given attachment is referenced.',
+      inputSchema: {
+        ...commonSiteArg,
+        id: z.number().int().positive(),
+        scope: z
+          .enum(['fast', 'full'])
+          .optional()
+          .describe('fast (REST) or full (WP-CLI required)'),
+        updateTo: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe('Rewrite references to point to a different attachment ID'),
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      const argv = ['references', String(a.id)];
+      opt(argv, '--scope', a.scope);
+      opt(argv, '--update-to', a.updateTo);
+      return runCli(argv, a.site as string | undefined);
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Processing
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    'optimize',
+    {
+      title: 'Optimize images',
+      description:
+        'Compress images using the local image engine. Bulk modes (--unoptimized, --all) are dry-run by default; pass apply=true to execute.',
+      inputSchema: {
+        ...commonSiteArg,
+        ids: z.array(z.number().int().positive()).optional().describe('Specific attachment IDs'),
+        unoptimized: z.boolean().optional().describe('Process all unoptimized items'),
+        all: z.boolean().optional().describe('Process every attachment'),
+        quality: z.number().int().min(1).max(100).optional(),
+        format: z.enum(['webp', 'avif', 'jpeg', 'png']).optional(),
+        maxWidth: z.number().int().positive().optional(),
+        maxHeight: z.number().int().positive().optional(),
+        encoder: z.enum(['sharp', 'jsquash']).optional(),
+        profile: z.string().optional().describe('Use a named profile from config'),
+        stripMetadata: z.boolean().optional(),
+        apply: z.boolean().optional().describe('Opt out of dry-run for bulk ops'),
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      const argv = ['optimize'];
+      ids(argv, a.ids);
+      flag(argv, '--unoptimized', a.unoptimized);
+      flag(argv, '--all', a.all);
+      opt(argv, '--quality', a.quality);
+      opt(argv, '--format', a.format);
+      opt(argv, '--max-width', a.maxWidth);
+      opt(argv, '--max-height', a.maxHeight);
+      opt(argv, '--encoder', a.encoder);
+      opt(argv, '--profile', a.profile);
+      flag(argv, '--strip-metadata', a.stripMetadata);
+      flag(argv, '--apply', a.apply);
+      return runCli(argv, a.site as string | undefined);
+    },
+  );
+
+  server.registerTool(
+    'convert',
+    {
+      title: 'Convert image format',
+      description: 'Convert attachments to a different format (webp, avif, jpeg, png).',
+      inputSchema: {
+        ...commonSiteArg,
+        ids: z.array(z.number().int().positive()).optional(),
+        all: z.boolean().optional(),
+        to: z.enum(['webp', 'avif', 'jpeg', 'png']).describe('Target format'),
+        quality: z.number().int().min(1).max(100).optional(),
+        apply: z.boolean().optional(),
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      const argv = ['convert'];
+      ids(argv, a.ids);
+      flag(argv, '--all', a.all);
+      opt(argv, '--to', a.to);
+      opt(argv, '--quality', a.quality);
+      flag(argv, '--apply', a.apply);
+      return runCli(argv, a.site as string | undefined);
+    },
+  );
+
+  server.registerTool(
+    'resize',
+    {
+      title: 'Resize images',
+      description:
+        'Resize attachments with a max-width or max-height constraint (aspect-preserving).',
+      inputSchema: {
+        ...commonSiteArg,
+        ids: z.array(z.number().int().positive()).optional(),
+        all: z.boolean().optional(),
+        maxWidth: z.number().int().positive().optional(),
+        maxHeight: z.number().int().positive().optional(),
+        apply: z.boolean().optional(),
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      const argv = ['resize'];
+      ids(argv, a.ids);
+      flag(argv, '--all', a.all);
+      opt(argv, '--max-width', a.maxWidth);
+      opt(argv, '--max-height', a.maxHeight);
+      flag(argv, '--apply', a.apply);
+      return runCli(argv, a.site as string | undefined);
+    },
+  );
+
+  server.registerTool(
+    'remove_bg',
+    {
+      title: 'Remove image background',
+      description:
+        'Remove background using a local AI model. Available models: birefnet-lite (best, ~224MB), isnet-general-use, u2net (default), silueta, u2netp (fast).',
+      inputSchema: {
+        ...commonSiteArg,
+        ids: z.array(z.number().int().positive()),
+        model: z
+          .enum(['birefnet-lite', 'isnet-general-use', 'u2net', 'silueta', 'u2netp'])
+          .optional(),
+        bg: z
+          .string()
+          .optional()
+          .describe('Background fill color (e.g. "#ffffff") instead of transparency'),
+        rembg: z.boolean().optional().describe('Use system Python rembg instead of built-in ONNX'),
+        rembgModel: z.string().optional().describe('Model name when using --rembg'),
+        apply: z.boolean().optional(),
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      const argv = ['remove-bg'];
+      ids(argv, a.ids);
+      opt(argv, '--model', a.model);
+      opt(argv, '--bg', a.bg);
+      flag(argv, '--rembg', a.rembg);
+      opt(argv, '--rembg-model', a.rembgModel);
+      flag(argv, '--apply', a.apply);
+      return runCli(argv, a.site as string | undefined);
+    },
+  );
+
+  server.registerTool(
+    'caption',
+    {
+      title: 'Generate alt text (AI)',
+      description:
+        'Generate alt text using a local Ollama vision model. Requires Ollama running at http://localhost:11434.',
+      inputSchema: {
+        ...commonSiteArg,
+        ids: z.array(z.number().int().positive()).optional(),
+        missingAlt: z
+          .boolean()
+          .optional()
+          .describe('Caption everything currently missing alt text'),
+        all: z.boolean().optional(),
+        model: z.string().optional().describe('Ollama model name (default: moondream)'),
+        language: z.string().optional().describe('Output language (e.g. "Spanish")'),
+        overwrite: z.boolean().optional(),
+        listModels: z.boolean().optional().describe('List locally available vision models'),
+        apply: z.boolean().optional(),
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      const argv = ['caption'];
+      ids(argv, a.ids);
+      flag(argv, '--missing-alt', a.missingAlt);
+      flag(argv, '--all', a.all);
+      opt(argv, '--model', a.model);
+      opt(argv, '--language', a.language);
+      flag(argv, '--overwrite', a.overwrite);
+      flag(argv, '--list-models', a.listModels);
+      flag(argv, '--apply', a.apply);
+      return runCli(argv, a.site as string | undefined);
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Round-trip & low-level
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    'pull',
+    {
+      title: 'Download attachments',
+      description: 'Download attachment files to a local directory.',
+      inputSchema: {
+        ...commonSiteArg,
+        ids: z.array(z.number().int().positive()),
+        to: z.string().optional().describe('Destination directory (default: current dir)'),
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      const argv = ['pull'];
+      ids(argv, a.ids);
+      opt(argv, '--to', a.to);
+      return runCli(argv, a.site as string | undefined);
+    },
+  );
+
+  server.registerTool(
+    'push',
+    {
+      title: 'Upload a local file to WordPress',
+      description:
+        'Upload a local file as a new attachment, or as a replacement for an existing one.',
+      inputSchema: {
+        ...commonSiteArg,
+        file: z.string().describe('Path to the local file to upload'),
+        replace: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe('Replace an existing attachment ID'),
+        title: z.string().optional(),
+        altText: z.string().optional(),
+        caption: z.string().optional(),
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      const argv = ['push', a.file as string];
+      opt(argv, '--replace', a.replace);
+      opt(argv, '--title', a.title);
+      opt(argv, '--alt-text', a.altText);
+      opt(argv, '--caption', a.caption);
+      return runCli(argv, a.site as string | undefined);
+    },
+  );
+
+  server.registerTool(
+    'regenerate',
+    {
+      title: 'Regenerate thumbnails',
+      description:
+        'Regenerate WordPress thumbnail sizes for one or more attachments (requires WP-CLI).',
+      inputSchema: {
+        ...commonSiteArg,
+        ids: z.array(z.number().int().positive()).optional(),
+        all: z.boolean().optional(),
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      const argv = ['regenerate'];
+      ids(argv, a.ids);
+      flag(argv, '--all', a.all);
+      return runCli(argv, a.site as string | undefined);
+    },
+  );
+
+  server.registerTool(
+    'export',
+    {
+      title: 'Export media library',
+      description: 'Export attachments to a local directory or ZIP archive.',
+      inputSchema: {
+        ...commonSiteArg,
+        ids: z.array(z.number().int().positive()).optional(),
+        all: z.boolean().optional(),
+        unoptimized: z.boolean().optional(),
+        to: z.string().describe('Destination file (.zip) or directory'),
+        type: z.string().optional(),
+        since: z.string().optional(),
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      const argv = ['export'];
+      ids(argv, a.ids);
+      flag(argv, '--all', a.all);
+      flag(argv, '--unoptimized', a.unoptimized);
+      opt(argv, '--to', a.to);
+      opt(argv, '--type', a.type);
+      opt(argv, '--since', a.since);
+      return runCli(argv, a.site as string | undefined);
+    },
+  );
+
+  server.registerTool(
+    'import',
+    {
+      title: 'Import local files into WordPress',
+      description: 'Bulk import a directory of local files, optionally optimizing on the way in.',
+      inputSchema: {
+        ...commonSiteArg,
+        source: z.string().describe('Path to a directory of files, or to a previous export .zip'),
+        optimize: z.boolean().optional(),
+        to: z
+          .enum(['webp', 'avif', 'jpeg', 'png'])
+          .optional()
+          .describe('Target format if --optimize'),
+        maxWidth: z.number().int().positive().optional(),
+        preserveIds: z.boolean().optional(),
+        dryRun: z.boolean().optional(),
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      const argv = ['import', a.source as string];
+      flag(argv, '--optimize', a.optimize);
+      opt(argv, '--to', a.to);
+      opt(argv, '--max-width', a.maxWidth);
+      flag(argv, '--preserve-ids', a.preserveIds);
+      flag(argv, '--dry-run', a.dryRun);
+      return runCli(argv, a.site as string | undefined);
+    },
+  );
+}

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -1,0 +1,115 @@
+/**
+ * MCP server round-trip tests.
+ *
+ * Boots `localpress mcp` as a real subprocess, drives it with the MCP SDK's
+ * client, and asserts on the protocol-level responses. No mocks.
+ *
+ * These are unit-grade because no WordPress is required — we only exercise
+ * tools/resources that work without network calls (listTools, listResources,
+ * and a sites_list call against an empty config).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+async function connectClient(): Promise<{ client: Client; close: () => Promise<void> }> {
+  // Isolated XDG_CONFIG_HOME so we don't read or write the user's real config.
+  const tmpHome = mkdtempSync(join(tmpdir(), 'localpress-mcp-test-'));
+
+  const transport = new StdioClientTransport({
+    command: process.execPath, // bun binary
+    args: ['run', join(import.meta.dir, '..', '..', 'src', 'cli', 'index.ts'), 'mcp'],
+    env: {
+      ...process.env,
+      XDG_CONFIG_HOME: tmpHome,
+    },
+    stderr: 'pipe',
+  });
+
+  const client = new Client({ name: 'localpress-test', version: '0.0.0' });
+  await client.connect(transport);
+
+  return {
+    client,
+    close: async () => {
+      await client.close();
+      rmSync(tmpHome, { recursive: true, force: true });
+    },
+  };
+}
+
+describe('mcp server', () => {
+  test('lists all registered tools', async () => {
+    const { client, close } = await connectClient();
+    try {
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name).sort();
+
+      // Spot-check core tools are present.
+      expect(names).toContain('sites_list');
+      expect(names).toContain('doctor');
+      expect(names).toContain('list');
+      expect(names).toContain('optimize');
+      expect(names).toContain('caption');
+      expect(names).toContain('remove_bg');
+
+      // Sanity: we expose ≥ 20 tools.
+      expect(tools.length).toBeGreaterThanOrEqual(20);
+    } finally {
+      await close();
+    }
+  }, 30_000);
+
+  test('lists all registered resources', async () => {
+    const { client, close } = await connectClient();
+    try {
+      const { resources } = await client.listResources();
+      const uris = resources.map((r) => r.uri).sort();
+      expect(uris).toEqual([
+        'localpress://capabilities',
+        'localpress://sites',
+        'localpress://stats',
+      ]);
+    } finally {
+      await close();
+    }
+  }, 30_000);
+
+  test('sites_list returns empty array against fresh config', async () => {
+    const { client, close } = await connectClient();
+    try {
+      const result = await client.callTool({ name: 'sites_list', arguments: {} });
+      // CLI prints "No sites configured" to stdout in non-JSON mode but to
+      // structured JSON in --json mode. We pass --json from the server, so the
+      // tool result should contain a parsable structure.
+      expect(result.isError).toBeFalsy();
+      // structuredContent may or may not be set depending on CLI output shape;
+      // at minimum, content should be present.
+      expect(Array.isArray(result.content)).toBe(true);
+    } finally {
+      await close();
+    }
+  }, 30_000);
+
+  test('tools advertise input schemas', async () => {
+    const { client, close } = await connectClient();
+    try {
+      const { tools } = await client.listTools();
+      const optimize = tools.find((t) => t.name === 'optimize');
+      expect(optimize).toBeDefined();
+      expect(optimize?.inputSchema).toBeDefined();
+      // Optimize takes ids + flags
+      const schema = optimize?.inputSchema as { properties?: Record<string, unknown> };
+      expect(schema.properties).toBeDefined();
+      expect(schema.properties).toHaveProperty('ids');
+      expect(schema.properties).toHaveProperty('quality');
+      expect(schema.properties).toHaveProperty('apply');
+    } finally {
+      await close();
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

- Adds `localpress mcp`: a stdio Model Context Protocol server that lets any MCP host (Claude Desktop, Cursor, Claude Code, etc.) drive localpress through typed tool calls.
- Exposes **20 tools** (setup, discovery, processing, library ops) and **3 resources** (sites, stats, capabilities), all backed by the existing CLI's `--json` contract.
- Ships as **v1.14.0** — minor, additive, no breaking changes.

Closes #45.

## Design

Tools dispatch by recursively spawning the localpress binary with `--json --quiet` (see `src/cli/mcp/invoke.ts`). This reuses the CLI's stable JSON shapes that the skill already depends on, so every CLI feature appears in the MCP server for free and new CLI features auto-propagate. Hot paths can later migrate to in-process dispatch without breaking schemas.

The MCP SDK is lazy-loaded — CLI startup time is unaffected when not running as an MCP server.

Site selection mirrors the CLI: every tool accepts an optional `site` arg; when omitted, the active site from config is used.

## What's exposed

**Tools (20):**
- *Setup:* `sites_list`, `sites_use`, `sites_add`, `sites_remove`, `doctor`, `config_get`, `config_set`, `config_list_profiles`, `config_get_profile`, `config_set_profile`
- *Discovery:* `list`, `show`, `stats`, `audit`, `references`
- *Processing:* `optimize`, `convert`, `resize`, `remove_bg`, `caption`
- *Library ops:* `pull`, `push`, `regenerate`, `export`, `import`

**Resources (3):** `localpress://sites`, `localpress://stats`, `localpress://capabilities`

**Not exposed (intentional):** `edit`, `watch`, `init`, `update`, `completions` — these require TTY and aren't meaningful in an agentic context.

## Host config

```jsonc
{
  "mcpServers": {
    "localpress": { "command": "localpress", "args": ["mcp"] }
  }
}
```

## Files

- `src/cli/commands/mcp.ts` — `localpress mcp` subcommand (lazy-loads server)
- `src/cli/mcp/server.ts` — boots `McpServer` + stdio transport
- `src/cli/mcp/tools.ts` — 20 tool definitions with Zod schemas
- `src/cli/mcp/resources.ts` — 3 read-only resources
- `src/cli/mcp/invoke.ts` — recursive CLI invocation with JSON parsing
- `test/unit/mcp.test.ts` — round-trip integration tests via the SDK client

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test` — 166 pass, 0 fail (4 new MCP tests)
- [x] `bun run dev -- mcp` boots and waits on stdin (manual smoke)
- [ ] CI green
- [ ] Manual test: wire into Claude Desktop locally and call `sites_list`, `doctor`, `list` against a real site

## Follow-ups (not in this PR)

- Progress streaming for long-running ops (would require migrating those tools to in-process dispatch)
- Optional MCP prompts for compound workflows (`audit-and-fix`, etc.)
- McpAdapter (a *backend* adapter that talks to a third-party WP MCP — separate concern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
