### PR TITLE
fix(mcp): optimize tool maps to --to, not --format

### DIFF
--- a/src/cli/mcp/tools.ts
+++ b/src/cli/mcp/tools.ts
@@ -419,7 +419,12 @@ export function registerTools(server: McpServer): void {
         unoptimized: z.boolean().optional().describe('Process all unoptimized items'),
         all: z.boolean().optional().describe('Process every attachment'),
         quality: z.number().int().min(1).max(100).optional(),
-        format: z.enum(['webp', 'avif', 'jpeg', 'png']).optional(),
+        to: z
+          .enum(['webp', 'avif', 'jpeg', 'png'])
+          .optional()
+          .describe(
+            'Convert during optimization: webp, avif, jpeg, or png. Defaults to the source format when omitted.',
+          ),
         maxWidth: z.number().int().positive().optional(),
         maxHeight: z.number().int().positive().optional(),
         encoder: z.enum(['sharp', 'jsquash']).optional(),
@@ -435,7 +440,7 @@ export function registerTools(server: McpServer): void {
       flag(argv, '--unoptimized', a.unoptimized);
       flag(argv, '--all', a.all);
       opt(argv, '--quality', a.quality);
-      opt(argv, '--format', a.format);
+      opt(argv, '--to', a.to);
       opt(argv, '--max-width', a.maxWidth);
       opt(argv, '--max-height', a.maxHeight);
       opt(argv, '--encoder', a.encoder);

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -127,4 +127,19 @@ describe('mcp server', () => {
       await close();
     }
   }, 30_000);
+
+  test('optimize tool exposes `to` (not `format`) — regression for #50', async () => {
+    // Bug: the optimize MCP tool used to advertise a `format` field that got
+    // mapped to `--format`, but the CLI takes `--to`. Verify the rename to `to`.
+    const { client, close } = await connectClient();
+    try {
+      const { tools } = await client.listTools();
+      const optimize = tools.find((t) => t.name === 'optimize');
+      const schema = optimize?.inputSchema as { properties?: Record<string, unknown> };
+      expect(schema.properties).toHaveProperty('to');
+      expect(schema.properties).not.toHaveProperty('format');
+    } finally {
+      await close();
+    }
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary

The MCP optimize tool advertised a `format` field that mapped to `--format`, but the CLI uses `--to` for format conversion during optimization. Agent calls with `format: "webp"` silently failed.

Renames the input field to `to` (matching the CLI flag and the convention used elsewhere) and updates the argv builder accordingly. Adds a regression test.

Closes #50.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test test/unit/mcp.test.ts` — 6/6 pass (1 new regression test)
- [ ] CI green

## Note for consumers

This is a **breaking change for the MCP tool input shape** in the strict sense — clients that previously passed `format` were already silently failing, so no working integration is broken. The new `to` field is the one that actually does what users expect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)