### PR TITLE
feat(list): add --search / query filter for finding by filename or title

### DIFF
--- a/src/adapters/rest.ts
+++ b/src/adapters/rest.ts
@@ -397,6 +397,9 @@ function applyCommonFilters(params: Record<string, string | number>, filters: Li
   if (filters.since) {
     params.after = filters.since;
   }
+  if (filters.search) {
+    params.search = filters.search;
+  }
 }
 
 function applySizeSort(items: MediaItem[], filters: ListFilters): MediaItem[] {

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -71,6 +71,8 @@ export interface ListFilters {
   since?: string;
   /** Bytes — only items larger than this. */
   largerThan?: number;
+  /** Free-text search across filename and title. Maps to WP REST `?search=` natively. */
+  search?: string;
   /** Sort field. 'size' is applied client-side; others pass to the REST API. */
   sortBy?: SortField;
   /** Sort direction. */

--- a/src/adapters/wp-cli.ts
+++ b/src/adapters/wp-cli.ts
@@ -105,6 +105,11 @@ export class WpCliAdapter implements WpBackend {
     if (filters.postId) {
       args.push(`--post_parent=${filters.postId}`);
     }
+    if (filters.search) {
+      // WP-CLI passes --s through to WP_Query, which searches post_title +
+      // post_content. Shell-escape since this goes through an SSH command.
+      args.push(`--s=${JSON.stringify(filters.search)}`);
+    }
     if (filters.perPage) {
       args.push(`--posts_per_page=${filters.perPage}`);
     }

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -25,6 +25,7 @@ export function registerListCommand(program: Command): void {
     )
     .option('--since <date>', 'only items uploaded since this ISO date')
     .option('--larger-than <bytes>', 'minimum size in bytes', (v) => Number.parseInt(v, 10))
+    .option('--search <term>', 'free-text search across filename and title')
     .option('--limit <n>', 'items per page (max 100)', (v) => Number.parseInt(v, 10))
     .option('--page <n>', 'page number (default 1)', (v) => Number.parseInt(v, 10))
     .option('--sort <field>', 'sort by: date (default), name, size, id')
@@ -45,6 +46,7 @@ export function registerListCommand(program: Command): void {
         postId: options.post,
         since: options.since,
         largerThan: options.largerThan,
+        search: options.search,
         perPage: Math.min(options.limit ?? 50, 100),
         page: options.page ?? 1,
         sortBy: VALID_SORT_FIELDS.includes(options.sort) ? (options.sort as SortField) : undefined,

--- a/src/cli/mcp/tools.ts
+++ b/src/cli/mcp/tools.ts
@@ -265,7 +265,7 @@ export function registerTools(server: McpServer): void {
     {
       title: 'List media items',
       description:
-        "List media in the active site's library. Filters compose: unoptimized, type, size, post association, date range.",
+        "List media in the active site's library. Filters compose: unoptimized, type, size, post association, date range, free-text search.",
       inputSchema: {
         ...commonSiteArg,
         unoptimized: z.boolean().optional().describe("Only items localpress hasn't processed yet"),
@@ -278,6 +278,10 @@ export function registerTools(server: McpServer): void {
           .describe('Attachments associated with a specific post'),
         since: z.string().optional().describe('ISO date — only items uploaded since this date'),
         largerThan: z.number().int().positive().optional().describe('Minimum size in bytes'),
+        search: z
+          .string()
+          .optional()
+          .describe('Free-text search across filename and title (WP REST native `?search=`)'),
         limit: z.number().int().positive().max(100).optional().describe('Items per page'),
         page: z.number().int().positive().optional().describe('Page number'),
         sort: z.enum(['date', 'name', 'size', 'id']).optional(),
@@ -292,6 +296,7 @@ export function registerTools(server: McpServer): void {
       opt(argv, '--post', a.post);
       opt(argv, '--since', a.since);
       opt(argv, '--larger-than', a.largerThan);
+      opt(argv, '--search', a.search);
       opt(argv, '--limit', a.limit);
       opt(argv, '--page', a.page);
       opt(argv, '--sort', a.sort);


### PR DESCRIPTION
## Summary

Adds free-text search across filename and title — agents (and humans) can find specific images without paginating the whole library.

Closes #53.

## Surface

\`\`\`bash
localpress list --search hero
localpress list --search \"logo\" --type image/png
localpress list --search \"screenshot\" --json
\`\`\`

MCP \`list\` tool gains a \`search\` field.

## Implementation

- \`ListFilters\` gains \`search?: string\`
- \`RestAdapter\` forwards to WP REST native \`?search=\` (server-side, indexed)
- \`WpCliAdapter\` forwards to \`wp post list --s=<term>\` (JSON-escaped for the SSH command)
- Composes with existing filters (\`type\`, \`largerThan\`, \`since\`, etc.) — they all stack

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] \`bun test\` — all existing tests pass
- [ ] CI green
- [ ] Manual: \`localpress list --search hero --json\` against a live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)