### PR TITLE
feat(mcp): minimal watch_status tool

### DIFF
--- a/src/cli/commands/watch-status.ts
+++ b/src/cli/commands/watch-status.ts
@@ -1,0 +1,64 @@
+/**
+ * `localpress watch-status` — report watcher orchestration state.
+ *
+ * Reports which directories have been watched for the active site, file
+ * counts, and last activity timestamps. Useful for agents to check
+ * "is automation already wired up here?" before starting their own ops.
+ *
+ * NOTE: this command does not detect a running watcher process — only
+ * whether watch_mappings rows exist. A future enhancement could write a
+ * pid file from the long-running `watch` command and check liveness.
+ * For v1 the historical mapping data is the honest signal we can give.
+ */
+
+import type { Command } from 'commander';
+import { SiteDb } from '../../engine/state/db.ts';
+import { getSiteDbPath, loadConfig, resolveActiveSite } from '../utils/config.ts';
+import { info, printJson } from '../utils/output.ts';
+
+export function registerWatchStatusCommand(program: Command): void {
+  program
+    .command('watch-status')
+    .description(
+      'Report which directories have been watched on the active site (file→attachment mappings).',
+    )
+    .action(async () => {
+      const parentOpts = program.opts();
+      const config = await loadConfig();
+      const site = resolveActiveSite(config, parentOpts.site);
+      const db = SiteDb.init(getSiteDbPath(site.name));
+
+      const directories = db.summarizeWatchDirectories(site.name);
+      db.close();
+
+      // "running" is honest here: we can't yet detect a live process, so we
+      // report false. Once a pid-file scheme exists, this becomes accurate.
+      const payload = {
+        site: site.name,
+        running: false,
+        runningDetectionImplemented: false,
+        directories,
+      };
+
+      if (parentOpts.json) {
+        printJson(payload);
+        return;
+      }
+
+      if (directories.length === 0) {
+        info(`  No watch history for site '${site.name}'.`);
+        info('  Start a watcher with: localpress watch <directory>');
+        return;
+      }
+
+      info(`  Watch history for ${site.name}:`);
+      for (const d of directories) {
+        const when = new Date(d.lastActivityAt).toLocaleString();
+        info(`    ${d.watchDir}  (${d.fileCount} files, last activity ${when})`);
+      }
+      info('');
+      info(
+        '  Note: live-process detection is not yet implemented. This report shows historical mappings only.',
+      );
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -36,6 +36,7 @@ import { registerSitesCommand } from './commands/sites.ts';
 import { registerStatsCommand } from './commands/stats.ts';
 import { registerUndoCommand } from './commands/undo.ts';
 import { registerUpdateCommand } from './commands/update.ts';
+import { registerWatchStatusCommand } from './commands/watch-status.ts';
 import { registerWatchCommand } from './commands/watch.ts';
 import { setOutputOptions } from './utils/output.ts';
 
@@ -95,6 +96,7 @@ registerHistoryCommand(program);
 registerUndoCommand(program);
 registerUpdateCommand(program);
 registerWatchCommand(program);
+registerWatchStatusCommand(program);
 registerCompletionsCommand(program);
 registerMcpCommand(program);
 

--- a/src/cli/mcp/tools.ts
+++ b/src/cli/mcp/tools.ts
@@ -952,4 +952,24 @@ export function registerTools(server: McpServer): void {
       return runCli(argv, a.site as string | undefined);
     },
   );
+
+  // ---------------------------------------------------------------------------
+  // Watch automation (read-only status; start/stop intentionally not exposed)
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    'watch_status',
+    {
+      title: 'Watch automation status',
+      description:
+        "Report which directories have been watched on the active site (file→attachment mappings) and last activity timestamps. NOTE: does not currently detect a live watcher process — only historical mapping data. Useful for agents to check 'is automation already wired up here?' before starting their own ops.",
+      inputSchema: {
+        ...commonSiteArg,
+      },
+    },
+    async (args) => {
+      const a = args as ArgMap;
+      return runCli(['watch-status'], a.site as string | undefined);
+    },
+  );
 }

--- a/src/engine/state/db.ts
+++ b/src/engine/state/db.ts
@@ -437,6 +437,34 @@ export class SiteDb {
 
     return rows.map(mapWatchMappingRow);
   }
+
+  /**
+   * Summary of every directory that has ever been watched on a site.
+   * Returns one row per unique watch_dir with file count + most-recent
+   * activity timestamp. Used by `watch-status` to report orchestration state.
+   */
+  summarizeWatchDirectories(
+    siteName: string,
+  ): Array<{ watchDir: string; fileCount: number; lastActivityAt: number }> {
+    const rows = this.db
+      .query(
+        `SELECT watch_dir, COUNT(*) AS file_count, MAX(updated_at) AS last_activity
+         FROM watch_mappings
+         WHERE site_name = ?
+         GROUP BY watch_dir
+         ORDER BY last_activity DESC`,
+      )
+      .all(siteName) as Array<{
+      watch_dir: string;
+      file_count: number;
+      last_activity: number;
+    }>;
+    return rows.map((r) => ({
+      watchDir: r.watch_dir,
+      fileCount: r.file_count,
+      lastActivityAt: r.last_activity,
+    }));
+  }
 }
 
 // -- Internal row types and mappers -------------------------------------------

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -80,6 +80,17 @@ describe('mcp server', () => {
     }
   }, 30_000);
 
+  test('watch_status tool is registered', async () => {
+    const { client, close } = await connectClient();
+    try {
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name);
+      expect(names).toContain('watch_status');
+    } finally {
+      await close();
+    }
+  }, 30_000);
+
   test('time-machine tools are registered', async () => {
     const { client, close } = await connectClient();
     try {


### PR DESCRIPTION
## Summary

Adds a \`watch_status\` MCP tool and matching \`localpress watch-status\` CLI command. Reports which directories have been watched on the active site (historical \`watch_mappings\` data) + last activity timestamps. Useful for agents to check "is automation already wired up here?" before starting their own ops.

Closes #56.

## Not exposed (intentional)

- \`watch_start\` / \`watch_stop\` — the watcher is a long-lived foreground process. Running it inside a stdio MCP subprocess is unusual and niche. Deferred until clearer demand.

## Honest about limitations

Live-process detection isn't yet implemented. The tool returns:

\`\`\`jsonc
{
  \"site\": \"...\",
  \"running\": false,
  \"runningDetectionImplemented\": false,
  \"directories\": [
    { \"watchDir\": \"/abs/path\", \"fileCount\": 42, \"lastActivityAt\": 1746979200000 }
  ]
}
\`\`\`

Once a pid-file scheme exists, the \`running\` field becomes accurate without changing the schema.

## Changes

- New \`SiteDb.summarizeWatchDirectories()\` aggregates \`watch_mappings\` per directory
- New CLI command \`localpress watch-status\` (hyphenated — \`watch <dir>\` has a positional that conflicts with adding a subcommand)
- New MCP tool \`watch_status\`
- Regression test asserts the tool is registered

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] \`bun test\` — 10/10 pass (1 new test)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)