### PR TITLE
fix(caption): FOREIGN KEY crash on per-item failure

### DIFF
--- a/src/cli/commands/caption.ts
+++ b/src/cli/commands/caption.ts
@@ -174,6 +174,22 @@ export function registerCaptionCommand(program: Command): void {
         try {
           const item = await getAdapter.getMedia(id);
 
+          // Ensure the attachment row exists before any recordProcessing call
+          // (processing_history has a FK on attachments). This runs
+          // unconditionally so failures during download / Ollama don't hit a
+          // FK violation in the catch block. Mirrors the pattern in remove-bg.
+          db.upsertAttachment({
+            siteName: site.name,
+            wpId: item.id,
+            sourceUrl: item.url,
+            sourceHash: null,
+            sizeBytes: item.sizeBytes ?? null,
+            width: item.width ?? null,
+            height: item.height ?? null,
+            mimeType: item.mimeType,
+            lastSeenAt: Date.now(),
+          });
+
           if (!item.mimeType.startsWith('image/')) {
             warn(`  ⚠ #${id} (${item.filename}) is not an image — skipping.`);
             continue;
@@ -278,21 +294,29 @@ export function registerCaptionCommand(program: Command): void {
           error(`    ✗ #${id}: ${message}`);
           failures++;
 
-          db.recordProcessing({
-            siteName: site.name,
-            wpId: id,
-            operation: 'caption',
-            paramsJson: JSON.stringify({ model: options.model }),
-            sourceHash: null,
-            resultHash: null,
-            bytesBefore: null,
-            bytesAfter: null,
-            resultWpId: null,
-            ranAt: Date.now(),
-            durationMs: Date.now() - startTime,
-            status: 'failure',
-            errorMessage: message,
-          });
+          // Wrap in try/catch — if the failure happened before the
+          // unconditional upsertAttachment (e.g. getMedia itself threw), the
+          // FK on processing_history would otherwise crash the whole loop.
+          // We'd rather lose the failure breadcrumb than abort the bulk run.
+          try {
+            db.recordProcessing({
+              siteName: site.name,
+              wpId: id,
+              operation: 'caption',
+              paramsJson: JSON.stringify({ model: options.model }),
+              sourceHash: null,
+              resultHash: null,
+              bytesBefore: null,
+              bytesAfter: null,
+              resultWpId: null,
+              ranAt: Date.now(),
+              durationMs: Date.now() - startTime,
+              status: 'failure',
+              errorMessage: message,
+            });
+          } catch {
+            // Best-effort breadcrumb; don't let it abort the loop.
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

When a caption attempt failed (e.g. Ollama 404 because the requested model isn't installed, or image download 404), the catch block called \`recordProcessing\` — which has a foreign key to the \`attachments\` table — without first upserting an attachment row. SQLite threw \`FOREIGN KEY constraint failed\` and aborted the whole bulk run instead of just skipping that item.

Reported by a user running \`caption --missing-alt\` without \`moondream\` installed:

\`\`\`
Captioning #2202 (...png)…
error:     ✗ #2202: Ollama returned 404: {\"error\":\"model 'moondream' not found\"}
error: FOREIGN KEY constraint failed
\`\`\`

That \`FOREIGN KEY constraint failed\` should have been "1 failed, continuing with the rest."

## Fix

Two-part, matching the pattern already in place on \`remove-bg.ts\`:

1. **Unconditional \`db.upsertAttachment\` right after \`getMedia\` succeeds** — ensures the FK target exists before any \`recordProcessing\` call, regardless of which downstream step fails
2. **Defensive try/catch around the failure-path \`recordProcessing\`** — belt-and-suspenders for cases where the upsert never ran (e.g. \`getMedia\` itself threw). Lose the breadcrumb rather than abort the bulk run.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] \`bun test\` — 181/181 pass
- [ ] CI green
- [ ] Manual repro: \`localpress caption --missing-alt\` with a non-existent default model should now report per-item failures and complete the loop instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)