### PR TITLE
feat(caption): add defaults.captionModel config key

### DIFF
--- a/src/cli/commands/caption.ts
+++ b/src/cli/commands/caption.ts
@@ -36,8 +36,7 @@ export function registerCaptionCommand(program: Command): void {
     .description('Generate alt-text for images using a local Ollama vision model')
     .option(
       '--model <name>',
-      `Ollama vision model to use (default: ${DEFAULT_OLLAMA_MODEL})`,
-      DEFAULT_OLLAMA_MODEL,
+      `Ollama vision model to use. Resolution order: --model > config.defaults.captionModel > built-in default (${DEFAULT_OLLAMA_MODEL})`,
     )
     .option('--prompt <text>', 'custom captioning prompt')
     .option(
@@ -83,20 +82,25 @@ export function registerCaptionCommand(program: Command): void {
         return;
       }
 
-      // Validate Ollama is reachable before doing any work.
-      if (!(await isOllamaAvailable(options.ollamaUrl))) {
-        error(
-          `Ollama is not running at ${options.ollamaUrl}.\n\n  Start it:       ollama serve\n  Pull a model:   ollama pull ${options.model}\n\n  Setup guide:    https://localpress.griffen.codes/docs/ollama-setup`,
-        );
-        process.exit(2);
-      }
-
       const config = await loadConfig();
       const site = resolveActiveSite(config, parentOpts.site);
       const resolver = new AdapterResolver(site);
       const listAdapter = resolver.resolve('list');
       const getAdapter = resolver.resolve('get');
       const updateAdapter = resolver.resolve('update-meta');
+
+      // Resolve the effective Ollama model:
+      //   --model flag > config.defaults.captionModel > built-in default
+      const effectiveModel: string =
+        options.model ?? config.defaults?.captionModel ?? DEFAULT_OLLAMA_MODEL;
+
+      // Validate Ollama is reachable before doing any work.
+      if (!(await isOllamaAvailable(options.ollamaUrl))) {
+        error(
+          `Ollama is not running at ${options.ollamaUrl}.\n\n  Start it:       ollama serve\n  Pull a model:   ollama pull ${effectiveModel}\n\n  Setup guide:    https://localpress.griffen.codes/docs/ollama-setup`,
+        );
+        process.exit(2);
+      }
 
       // Resolve which attachment IDs to process.
       let ids: number[];
@@ -153,7 +157,7 @@ export function registerCaptionCommand(program: Command): void {
       const historySession =
         historyConfig.enabled && !isDryRun
           ? openHistorySession(snapshotStore, site.name, 'caption', {
-              model: options.model,
+              model: effectiveModel,
               language: options.language,
               overwrite: options.overwrite ?? false,
             })
@@ -218,7 +222,7 @@ export function registerCaptionCommand(program: Command): void {
           const imageBuffer = Buffer.from(await response.arrayBuffer());
 
           const result = await generateCaption(imageBuffer, {
-            model: options.model,
+            model: effectiveModel,
             prompt: options.prompt,
             ollamaUrl: options.ollamaUrl,
             language: options.language,
@@ -303,7 +307,7 @@ export function registerCaptionCommand(program: Command): void {
               siteName: site.name,
               wpId: id,
               operation: 'caption',
-              paramsJson: JSON.stringify({ model: options.model }),
+              paramsJson: JSON.stringify({ model: effectiveModel }),
               sourceHash: null,
               resultHash: null,
               bytesBefore: null,

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -285,6 +285,15 @@ const SETTABLE_KEYS: Record<
       c.defaults.concurrency = n;
     },
   },
+  'defaults.captionModel': {
+    get: (c) => c.defaults?.captionModel,
+    set: (c, v) => {
+      const trimmed = v.trim();
+      if (!trimmed) throw new Error('captionModel must be a non-empty Ollama model name');
+      if (!c.defaults) c.defaults = {};
+      c.defaults.captionModel = trimmed;
+    },
+  },
   'history.enabled': {
     get: (c) => c.history?.enabled ?? true,
     set: (c, v) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,8 @@ export interface Config {
     format?: 'webp' | 'avif' | 'jpeg' | 'png';
     /** Default concurrency for bulk ops. */
     concurrency?: number;
+    /** Default Ollama vision model for `caption` (e.g. "moondream", "llava-llama3:latest"). */
+    captionModel?: string;
   };
   /** Time-machine / undo retention settings. */
   history?: {


### PR DESCRIPTION
## Summary

Lets users set their preferred Ollama vision model once instead of passing \`--model\` on every call. Useful when the installed vision model isn't moondream (the built-in default).

\`\`\`bash
localpress config set defaults.captionModel llava-llama3:latest
localpress caption --missing-alt --apply   # uses llava-llama3 now

# Explicit --model still wins
localpress caption 123 --model moondream
\`\`\`

Closes #65.

## Resolution order

\`--model\` (explicit flag) > \`config.defaults.captionModel\` (per-user) > \`moondream\` (built-in)

## Changes

- \`Config['defaults']\` gains \`captionModel?: string\`
- \`defaults.captionModel\` added to \`SETTABLE_KEYS\` (trim, reject empty)
- \`caption\` command resolves \`effectiveModel\` once at the top, replaces all \`options.model\` references
- Ollama-not-running error now references the resolved model
- Help text on \`--model\` describes the resolution order

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] \`bun test\` — 181/181 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)