### PR TITLE
feat(caption): pre-flight Ollama model availability check

### DIFF
--- a/src/cli/commands/caption.ts
+++ b/src/cli/commands/caption.ts
@@ -102,6 +102,47 @@ export function registerCaptionCommand(program: Command): void {
         process.exit(2);
       }
 
+      // Pre-flight: verify the resolved model is actually installed locally.
+      // Catches typos and "default model not pulled" cases BEFORE a 300-item
+      // bulk run fails the same way on every item.
+      try {
+        const installed = await listOllamaModels(options.ollamaUrl);
+        const installedNames = installed.map((m) => m.name);
+        const hasMatch = installedNames.some(
+          (n) =>
+            n === effectiveModel ||
+            n === `${effectiveModel}:latest` ||
+            n.startsWith(`${effectiveModel}:`),
+        );
+
+        if (!hasMatch) {
+          const visionModels = installedNames.filter((n) =>
+            /moondream|llava|bakllava|llama.*vision|qwen.*vl|minicpm|phi.*vision/i.test(n),
+          );
+
+          const visionList =
+            visionModels.length > 0
+              ? `\n\n  Your locally-available vision models:\n    ${visionModels.join('\n    ')}`
+              : '\n\n  No vision models installed locally.';
+
+          const remediation =
+            visionModels.length > 0
+              ? `  Or use one you already have:\n    localpress caption --model ${visionModels[0]} ...\n\n  Or set it as the project default:\n    localpress config set defaults.captionModel ${visionModels[0]}\n`
+              : '  Recommended starter model:\n    ollama pull moondream\n';
+
+          error(
+            `Ollama model '${effectiveModel}' is not available on ${options.ollamaUrl}.${visionList}\n\n  Pull the requested model:\n    ollama pull ${effectiveModel}\n\n${remediation}`,
+          );
+          process.exit(2);
+        }
+      } catch (preflightErr) {
+        // If the pre-flight check itself fails (e.g. network blip after the
+        // isOllamaAvailable probe), don't block the run — fall through to the
+        // bulk loop and let per-item failures handle it.
+        const m = preflightErr instanceof Error ? preflightErr.message : String(preflightErr);
+        warn(`Could not pre-flight check Ollama models (${m}); continuing anyway.`);
+      }
+
       // Resolve which attachment IDs to process.
       let ids: number[];
 


### PR DESCRIPTION
## Summary

Before starting a long-running caption loop (potentially 300+ items × 6-18s each), verify the resolved Ollama model is installed locally. Fail fast with an actionable error instead of failing the same way on every item.

Closes #66.

## Motivation

A user with \`llava-llama3:latest\` but no \`moondream\` ran \`localpress caption --missing-alt\`. Every one of 303 items failed with the same Ollama 404. A single \`/api/tags\` call at startup would have prevented all of it.

## Behavior

1. After the Ollama-reachability probe, fetch installed models via \`listOllamaModels\`
2. Match against the resolved model (exact, \`<name>:latest\`, or \`<name>:*\` prefix)
3. On miss, exit 2 with:

\`\`\`
error: Ollama model 'moondream' is not available on http://localhost:11434.

  Your locally-available vision models:
    llava-llama3:latest

  Pull the requested model:
    ollama pull moondream

  Or use one you already have:
    localpress caption --model llava-llama3:latest ...

  Or set it as the project default:
    localpress config set defaults.captionModel llava-llama3:latest
\`\`\`

If the pre-flight call itself errors (network blip after the reachability probe), warn and fall through — don't block the run on a flaky check.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] \`bun test\` — 181/181 pass (no regressions)
- [ ] CI green
- [ ] Manual: \`caption --missing-alt\` with a non-existent model exits before any per-item processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)