### PR TITLE
feat(list -i): show active site name in TUI header

### DIFF
--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -187,6 +187,7 @@ export function registerListCommand(program: Command): void {
               processedIds,
               sortBy: filters.sortBy,
               sortOrder: filters.sortOrder,
+              siteName: site.name,
               profiles: config.profiles
                 ? Object.entries(config.profiles).map(([name, p]) => ({
                     name,

--- a/src/cli/components/MediaBrowser.tsx
+++ b/src/cli/components/MediaBrowser.tsx
@@ -68,6 +68,8 @@ interface Props {
   processedIds: Set<number>;
   sortBy?: SortField;
   sortOrder?: SortOrder;
+  /** Active site name — shown in the header so the user knows which WP site they're browsing. */
+  siteName?: string;
   onAction: (action: MediaBrowserAction) => void;
   onPageChange: (page: number) => Promise<PagedResult<MediaItem>>;
   onFetchItem?: (id: number) => Promise<MediaItem>;
@@ -129,6 +131,7 @@ export function MediaBrowser({
   processedIds,
   sortBy,
   sortOrder,
+  siteName,
   onAction,
   onPageChange,
   onFetchItem,
@@ -1153,6 +1156,7 @@ export function MediaBrowser({
           <Text bold color="green">
             localPress
           </Text>
+          {siteName && <Text color="cyan">· {siteName}</Text>}
           <Text dimColor>— media library</Text>
           {sortBy && sortBy !== 'date' && (
             <Text dimColor>


### PR DESCRIPTION
## Summary

When \`localpress list -i\` boots, the header now reads \`localPress · <site name> — media library\` instead of just \`localPress\`. For users managing multiple WP sites, this is the visible signal of which site they're currently working against.

Closes #68.

## Before / after

Before:
\`\`\`
localPress — media library                  Page 1/12 · 303 total
\`\`\`

After:
\`\`\`
localPress · production — media library     Page 1/12 · 303 total
\`\`\`

## Changes

- \`MediaBrowser\` Props gain \`siteName?: string\` (optional — defensive against any future caller)
- Header renders the site name in cyan between the brand and the \"— media library\" subtitle when provided
- \`list.ts\` passes \`site.name\` through

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] \`bun test\` — 181/181 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)