### PR TITLE
fix(caption): pre-resize image + cap output + strip meta-phrases

### DIFF
--- a/src/engine/caption/ollama.ts
+++ b/src/engine/caption/ollama.ts
@@ -3,15 +3,35 @@
  *
  * Sends images to a locally-running Ollama instance and returns
  * generated alt-text. Requires a multimodal model such as:
- *   moondream  (~1.7GB, fast, great for alt-text)
- *   llava      (~4GB+, higher quality)
- *   bakllava   (~4GB+, alternative LLaVA variant)
+ *   moondream             (~1.7GB, fast, great for short alt-text)
+ *   llava-llama3          (~5.5GB, solid all-rounder)
+ *   llama3.2-vision:11b   (~8GB, best quality on screenshots/text-in-image)
+ *   bakllava              (~4GB+, alternative LLaVA variant)
+ *
+ * Three quality safeguards before the response reaches WordPress:
+ *   1. Pre-resize the image to <=1024px so smaller models don't blow
+ *      their context budget on 4K screenshots and bigger models run
+ *      faster (vision models don't need pixel-perfect input).
+ *   2. Cap Ollama's output with `num_predict` so verbose models can't
+ *      generate multi-paragraph essays as alt text.
+ *   3. Post-process the response: strip leading meta-phrases ("The
+ *      image shows…"), keep only the first paragraph, truncate cleanly
+ *      at a word boundary if it's still too long.
  */
 
 import type { CaptionOptions, CaptionResult } from './types.ts';
 
 export const DEFAULT_OLLAMA_MODEL = 'moondream';
 export const DEFAULT_OLLAMA_URL = 'http://localhost:11434';
+
+/** Vision models work fine on smaller inputs; pre-resize to this max edge. */
+const MAX_IMAGE_EDGE = 1024;
+
+/** Hard ceiling on Ollama-generated tokens to prevent verbose-model essays. */
+const MAX_OUTPUT_TOKENS = 200;
+
+/** Soft cap on the final caption length; truncate at a word boundary if exceeded. */
+const MAX_CAPTION_CHARS = 240;
 
 const DEFAULT_PROMPT =
   'Write concise alt-text for this image. Describe only what is visually present. ' +
@@ -65,12 +85,26 @@ export async function generateCaption(
   }
 
   const start = Date.now();
-  const b64 = imageBuffer.toString('base64');
+
+  // Pre-resize to keep the Ollama request small. Vision models max out
+  // perception around 1024px; larger inputs just waste compute and can
+  // overflow smaller models' context windows (e.g. moondream returning
+  // empty on 4K Mac screenshots).
+  const downscaled = await downscaleForVision(imageBuffer);
+  const b64 = downscaled.toString('base64');
 
   const res = await fetch(`${baseUrl}/api/generate`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ model, prompt, images: [b64], stream: false }),
+    body: JSON.stringify({
+      model,
+      prompt,
+      images: [b64],
+      stream: false,
+      // Hard cap on response length — defense against models that ignore
+      // "keep it short" instructions in the prompt.
+      options: { num_predict: MAX_OUTPUT_TOKENS },
+    }),
   });
 
   if (!res.ok) {
@@ -81,11 +115,103 @@ export async function generateCaption(
   const data = (await res.json()) as OllamaGenerateResponse;
 
   if (data.error) throw new Error(`Ollama error: ${data.error}`);
-  if (!data.response) throw new Error('Ollama returned an empty response');
+  if (!data.response || data.response.trim().length === 0) {
+    throw new Error(
+      'Ollama returned an empty response. The model may not be suited to this image — try a different --model.',
+    );
+  }
 
   return {
-    caption: data.response.trim(),
+    caption: cleanCaption(data.response),
     model,
     durationMs: Date.now() - start,
   };
+}
+
+/**
+ * Downscale the image to a max edge of 1024px before sending to Ollama.
+ *
+ * Vision models don't need pixel-perfect input — they typically resize
+ * to 224/336/672/1024 internally. Sending the original 4K Mac screenshot
+ * is pure waste and breaks tiny models. Returns the original bytes if
+ * sharp isn't available (graceful degradation — captions still work,
+ * just less reliably).
+ */
+async function downscaleForVision(imageBuffer: Buffer): Promise<Buffer> {
+  try {
+    const sharpMod = await import('sharp');
+    const sharp = sharpMod.default;
+    const meta = await sharp(imageBuffer).metadata();
+    const maxEdge = Math.max(meta.width ?? 0, meta.height ?? 0);
+    if (maxEdge <= MAX_IMAGE_EDGE) return imageBuffer;
+    return await sharp(imageBuffer)
+      .resize({
+        width: MAX_IMAGE_EDGE,
+        height: MAX_IMAGE_EDGE,
+        fit: 'inside',
+        withoutEnlargement: true,
+      })
+      .toBuffer();
+  } catch {
+    // sharp not installed or processing failed — fall back to original.
+    // Captions still work, just may be slower / more failure-prone.
+    return imageBuffer;
+  }
+}
+
+/**
+ * Post-process a raw Ollama response into clean alt-text.
+ *
+ * Handles three common failure modes:
+ *   - Verbose intros: "The image shows…", "Here is a description of…"
+ *   - Multi-paragraph essays: keep only the first paragraph
+ *   - Bulleted analyses: take everything up to the first list bullet
+ *   - Surrounding quotes: strip them (some models wrap output in "…")
+ *
+ * Final pass truncates at a word boundary if still over MAX_CAPTION_CHARS.
+ */
+export function cleanCaption(raw: string): string {
+  let s = raw.trim();
+
+  // Strip leading/trailing quotes ("text" or 'text').
+  s = s.replace(/^["']+|["']+$/g, '').trim();
+
+  // Take only the first paragraph (split on blank line).
+  const firstPara = s.split(/\n\s*\n/, 1)[0];
+  if (firstPara) s = firstPara.trim();
+
+  // Trim everything from the first list bullet onward (some models
+  // append a bulleted analysis after the actual sentence).
+  const bulletIdx = s.search(/\n\s*[*\-•]\s/);
+  if (bulletIdx > 0) s = s.slice(0, bulletIdx).trim();
+
+  // Strip common meta-phrase intros.
+  const introPatterns: RegExp[] = [
+    /^the image (shows|displays|depicts|features|contains)\s+/i,
+    /^this image (shows|displays|depicts|is\s+of|is)\s+/i,
+    /^here is a (short|brief|concise)?\s*(description|caption|alt[\s-]?text) of[^:.]*:?\s*/i,
+    /^here'?s? a (short|brief|concise)?\s*(description|caption|alt[\s-]?text)[^:.]*:?\s*/i,
+    /^the picture (shows|displays|depicts)\s+/i,
+    /^(a |an )?(screenshot|photo|photograph|image|picture) of\s+/i,
+    /^i (can )?see\s+/i,
+    /^description:\s*/i,
+    /^alt[\s-]?text:\s*/i,
+    /^caption:\s*/i,
+  ];
+  for (const re of introPatterns) {
+    if (re.test(s)) {
+      s = s.replace(re, '');
+      // Capitalize the new leading char.
+      if (s.length > 0) s = s[0].toUpperCase() + s.slice(1);
+      break;
+    }
+  }
+
+  // Truncate to a word boundary if still too long.
+  if (s.length > MAX_CAPTION_CHARS) {
+    const cutoff = s.lastIndexOf(' ', MAX_CAPTION_CHARS);
+    s = `${s.slice(0, cutoff > 0 ? cutoff : MAX_CAPTION_CHARS)}…`;
+  }
+
+  return s.trim();
 }

--- a/test/unit/caption-clean.test.ts
+++ b/test/unit/caption-clean.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for cleanCaption() — the post-processor that turns verbose
+ * Ollama responses into usable HTML alt-text.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { cleanCaption } from '../../src/engine/caption/ollama.ts';
+
+describe('cleanCaption', () => {
+  test('passes through already-clean alt text unchanged', () => {
+    expect(cleanCaption('Red ceramic mug on a wooden desk')).toBe(
+      'Red ceramic mug on a wooden desk',
+    );
+  });
+
+  test('strips surrounding quotes', () => {
+    expect(cleanCaption('"Red ceramic mug on a wooden desk"')).toBe(
+      'Red ceramic mug on a wooden desk',
+    );
+    expect(cleanCaption("'Red mug'")).toBe('Red mug');
+  });
+
+  test('strips "The image shows" intro and recapitalizes', () => {
+    expect(cleanCaption('The image shows a red coffee mug on a wooden desk.')).toBe(
+      'A red coffee mug on a wooden desk.',
+    );
+  });
+
+  test('strips "This image is" intro', () => {
+    expect(cleanCaption('This image is of a sunset over mountains.')).toBe(
+      'A sunset over mountains.',
+    );
+  });
+
+  test('strips "Here is a description of …:" intro', () => {
+    expect(cleanCaption('Here is a brief description of the image: A red mug.')).toBe('A red mug.');
+  });
+
+  test('strips "I see" intro', () => {
+    expect(cleanCaption('I see a cat sitting on a windowsill.')).toBe(
+      'A cat sitting on a windowsill.',
+    );
+  });
+
+  test('strips "Description:" leading label', () => {
+    expect(cleanCaption('Description: A red mug.')).toBe('A red mug.');
+    expect(cleanCaption('Alt-text: A red mug.')).toBe('A red mug.');
+  });
+
+  test('keeps only the first paragraph from multi-paragraph output', () => {
+    const verbose = `A terminal showing localpress output.
+
+* A header bar at the top
+* A list of attachment IDs below
+* Status text in green
+
+The terminal uses a dark color scheme.`;
+    expect(cleanCaption(verbose)).toBe('A terminal showing localpress output.');
+  });
+
+  test('cuts at first bullet point', () => {
+    const bulletEssay = `A terminal window with command output.
+* The terminal has a gray background
+* Text is displayed in white`;
+    expect(cleanCaption(bulletEssay)).toBe('A terminal window with command output.');
+  });
+
+  test('truncates very long output at a word boundary', () => {
+    const long = `${'word '.repeat(60)}word`; // 305 chars
+    const out = cleanCaption(long);
+    expect(out.length).toBeLessThanOrEqual(241);
+    expect(out.endsWith('…')).toBe(true);
+    // Truncation should land on a word boundary (last char before ellipsis is a letter).
+    expect(/[a-z]…$/.test(out)).toBe(true);
+  });
+
+  test('handles the real llama3.2-vision verbose output pattern', () => {
+    const real = `The image shows a screenshot of a terminal window displaying a command prompt with a list of commands and their outputs. The purpose of the image is to illustrate the use of various commands in a terminal environment.
+
+* A terminal window with a command prompt:
+        + The terminal window has a gray background with white text.
+
+Overall, the image provides a visual representation of the commands and their outputs.`;
+    const out = cleanCaption(real);
+    // First paragraph should win, intro should be stripped, no bullets.
+    expect(out).not.toContain('*');
+    expect(out).not.toContain('Overall');
+    expect(out.startsWith('A screenshot of a terminal window')).toBe(true);
+    expect(out.length).toBeLessThan(250);
+  });
+});


### PR DESCRIPTION
## Summary

Real-world test of \`caption\` surfaced two failure modes that both end up written to WordPress as alt attributes:

- **moondream** returned an empty response on a 4K Mac screenshot — its context budget was blown by the raw image bytes
- **llama3.2-vision:11b** produced a 1.5 KB multi-paragraph essay despite the prompt asking for ≤125 chars

Three independent safeguards now stack:

Closes #71.

## 1. Pre-resize before Ollama (fixes moondream empty response)
- Use sharp to fit the input within 1024×1024 max (vision models max out perception around this resolution; larger inputs just waste compute and break tiny models)
- Aspect-preserving, \`withoutEnlargement: true\`
- Falls back to original bytes if sharp isn't available (graceful degradation)

## 2. Hard cap on Ollama output via num_predict (fixes wall-of-text)
- Send \`options: { num_predict: 200 }\` in \`/api/generate\` body
- ~200 tokens ≈ 150-180 chars of typical English alt text — a defense regardless of how chatty the model decides to be

## 3. Post-process the response (fixes verbose models)
New pure \`cleanCaption()\` function:
- Strip surrounding quotes
- Keep only the first paragraph
- Cut at the first bullet point (models love appending bulleted analyses after their actual sentence)
- Strip meta-phrases: \"The image shows…\", \"This image is…\", \"Here is a description…\", \"I see…\", \"Description:\", etc.
- Recapitalize the leading char after intro stripping
- Truncate at a word boundary near 240 chars + ellipsis

## Better error on empty response

Instead of just \"Ollama returned an empty response\", suggest trying a different model.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] 11 new unit tests for \`cleanCaption\` — all pass, including a regression test against the real verbose llama3.2-vision output
- [x] Full suite: 192/192 pass
- [ ] CI green
- [ ] Manual repro: rerun the user's exact command on the same screenshot ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)