### PR TITLE
chore: migrate Homebrew install to unified gfargo/tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ name: Release
 #
 # Prerequisites:
 #   - HOMEBREW_TAP_TOKEN secret: a GitHub PAT with `repo` scope on
-#     the homebrew-localpress tap repository (gfargo/homebrew-localpress).
+#     the shared gfargo Homebrew tap (gfargo/homebrew-tap).
 
 on:
   push:
@@ -134,7 +134,7 @@ jobs:
             echo "HOMEBREW_TAP_TOKEN not set — skipping tap push. Add it to repo secrets to enable."
             exit 0
           fi
-          git clone https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/gfargo/homebrew-localpress.git /tmp/tap
+          git clone https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/gfargo/homebrew-tap.git /tmp/tap
           cp Formula/localpress.rb /tmp/tap/Formula/localpress.rb
           cd /tmp/tap
           git config user.name  "github-actions[bot]"

--- a/Formula/localpress.rb
+++ b/Formula/localpress.rb
@@ -2,14 +2,14 @@
 # frozen_string_literal: true
 
 # This formula is maintained in the localpress repository.
-# The Homebrew tap lives at https://github.com/gfargo/homebrew-localpress
+# The Homebrew tap lives at https://github.com/gfargo/homebrew-tap
 #
 # To install:
-#   brew tap gfargo/localpress
+#   brew tap gfargo/tap
 #   brew install localpress
 #
 # Or in one step:
-#   brew install gfargo/localpress/localpress
+#   brew install gfargo/tap/localpress
 
 class Localpress < Formula
   desc "Local-compute WordPress media optimization. Your laptop, your library."

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # localpress
 
 [![GitHub Release](https://img.shields.io/github/v/release/gfargo/localpress)](https://github.com/gfargo/localpress/releases)
-[![Homebrew](https://img.shields.io/badge/homebrew-gfargo%2Flocalpress-orange)](https://github.com/gfargo/homebrew-localpress)
+[![Homebrew](https://img.shields.io/badge/homebrew-gfargo%2Ftap-orange)](https://github.com/gfargo/homebrew-tap)
 [![License: MIT](https://img.shields.io/github/license/gfargo/localpress)](LICENSE)
 [![GitHub issues](https://img.shields.io/github/issues/gfargo/localpress)](https://github.com/gfargo/localpress/issues)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/gfargo/localpress)](https://github.com/gfargo/localpress/pulls)
@@ -24,7 +24,7 @@ Local-compute WordPress management CLI. Optimize media, manage posts and pages, 
 ### Homebrew (macOS / Linux)
 
 ```bash
-brew install gfargo/localpress/localpress
+brew install gfargo/tap/localpress
 ```
 
 ### Pre-built binaries

--- a/docs/blog-post-v2.md
+++ b/docs/blog-post-v2.md
@@ -217,7 +217,7 @@ The full roadmap has 450+ ideas across 61 domains: [docs/roadmap-ideas.md](https
 
 ```bash
 # New install
-brew install gfargo/localpress/localpress
+brew install gfargo/tap/localpress
 
 # Upgrade existing
 brew upgrade localpress


### PR DESCRIPTION
Migrates localpress's Homebrew install to the shared **`gfargo/homebrew-tap`** tap, part of unifying all gfargo formulae under one tap (gfargo/homebrew-localpress#1).

```diff
- brew install gfargo/localpress/localpress
+ brew install gfargo/tap/localpress
```

## Changes
- **`Formula/localpress.rb`** — header comment points at the shared tap + new install command.
- **`README.md`** — Homebrew badge links to `gfargo/homebrew-tap`; install command updated.
- **`docs/blog-post-v2.md`** — install snippet updated.
- **`.github/workflows/release.yml`** — the formula-push step now clones/pushes to `gfargo/homebrew-tap` (formula build / release-asset logic unchanged).

The formula already lives in the shared tap (`gfargo/homebrew-tap/Formula/localpress.rb`, ported from the old tap at v2.0.0).

## ⚠️ Action required after merge
The **`HOMEBREW_TAP_TOKEN`** secret on this repo must grant `repo` scope on **`gfargo/homebrew-tap`** (previously `gfargo/homebrew-localpress`) so the release workflow can push formula updates.