### PR TITLE
feat: VHS screenshot/GIF generation pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ name: Release
 #
 # Prerequisites:
 #   - HOMEBREW_TAP_TOKEN secret: a GitHub PAT with `repo` scope on
-#     the homebrew-localpress tap repository (gfargo/homebrew-localpress).
+#     the shared gfargo Homebrew tap (gfargo/homebrew-tap).
 
 on:
   push:
@@ -134,7 +134,7 @@ jobs:
             echo "HOMEBREW_TAP_TOKEN not set — skipping tap push. Add it to repo secrets to enable."
             exit 0
           fi
-          git clone https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/gfargo/homebrew-localpress.git /tmp/tap
+          git clone https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/gfargo/homebrew-tap.git /tmp/tap
           cp Formula/localpress.rb /tmp/tap/Formula/localpress.rb
           cd /tmp/tap
           git config user.name  "github-actions[bot]"

--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,10 @@ scratch/
 models/
 *.onnx
 
+# Screenshot pipeline raw output (regenerated, not committed)
+bin/screenshot/out/
+bin/screenshot/tapes/
+!bin/screenshot/out/.gitkeep
+
 # Local config (per-developer test sites)
 .localpress/

--- a/Formula/localpress.rb
+++ b/Formula/localpress.rb
@@ -2,14 +2,14 @@
 # frozen_string_literal: true
 
 # This formula is maintained in the localpress repository.
-# The Homebrew tap lives at https://github.com/gfargo/homebrew-localpress
+# The Homebrew tap lives at https://github.com/gfargo/homebrew-tap
 #
 # To install:
-#   brew tap gfargo/localpress
+#   brew tap gfargo/tap
 #   brew install localpress
 #
 # Or in one step:
-#   brew install gfargo/localpress/localpress
+#   brew install gfargo/tap/localpress
 
 class Localpress < Formula
   desc "Local-compute WordPress media optimization. Your laptop, your library."

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # localpress
 
 [![GitHub Release](https://img.shields.io/github/v/release/gfargo/localpress)](https://github.com/gfargo/localpress/releases)
-[![Homebrew](https://img.shields.io/badge/homebrew-gfargo%2Flocalpress-orange)](https://github.com/gfargo/homebrew-localpress)
+[![Homebrew](https://img.shields.io/badge/homebrew-gfargo%2Ftap-orange)](https://github.com/gfargo/homebrew-tap)
 [![License: MIT](https://img.shields.io/github/license/gfargo/localpress)](LICENSE)
 [![GitHub issues](https://img.shields.io/github/issues/gfargo/localpress)](https://github.com/gfargo/localpress/issues)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/gfargo/localpress)](https://github.com/gfargo/localpress/pulls)
@@ -24,7 +24,7 @@ Local-compute WordPress management CLI. Optimize media, manage posts and pages, 
 ### Homebrew (macOS / Linux)
 
 ```bash
-brew install gfargo/localpress/localpress
+brew install gfargo/tap/localpress
 ```
 
 ### Pre-built binaries

--- a/bin/screenshot/README.md
+++ b/bin/screenshot/README.md
@@ -1,0 +1,90 @@
+# Screenshot & Demo GIF Pipeline
+
+Generate deterministic marketing screenshots and demo GIFs of localpress using [Charm VHS](https://github.com/charmbracelet/vhs).
+
+## Prerequisites
+
+```bash
+brew install vhs         # terminal recorder (pulls in ffmpeg + ttyd)
+brew install gifsicle    # lossless GIF optimization
+```
+
+Verify: `vhs --version && gifsicle --version`
+
+## Usage
+
+```bash
+# Generate all screenshots and GIFs
+bun run screenshot
+
+# Generate a specific recipe
+bun run screenshot -- --recipe help-screen
+
+# List all available recipes
+bun run screenshot -- --list
+
+# Generate only stills (PNGs)
+bun run screenshot -- --stills
+
+# Generate only motion demos (GIFs)
+bun run screenshot -- --gifs
+```
+
+## Output
+
+- **Stills** → `.www/public/screenshots/<name>.png`
+- **GIFs** → `.www/public/screenshots/<name>.gif`
+
+Raw captures land in `bin/screenshot/out/` before optimization and sync.
+
+## Adding a New Recipe
+
+Edit `bin/screenshot/recipes.ts` and add a new entry to `RECIPES`:
+
+```ts
+{
+  name: 'my-new-shot',
+  description: 'Shows the frobnicate feature',
+  command: 'localpress frobnicate --site demo',
+  actions: [
+    { kind: 'sleep', ms: 2000 },
+  ],
+  emitGif: false, // true for motion, false for still
+}
+```
+
+Then run `bun run screenshot -- --recipe my-new-shot` to test it.
+
+## Architecture
+
+```
+bin/screenshot/
+├── README.md           # this file
+├── recipes.ts          # declarative scene catalog (data)
+├── tape.ts             # recipe → .tape string (pure transform)
+├── screenshot.ts       # driver: fixture → tape → vhs → optimize → output
+└── out/                # raw VHS output (gitignored)
+```
+
+## Determinism
+
+Every capture is reproducible because:
+
+- Fixed `FontSize` (20) — canvas sized by VHS defaults (1200×600)
+- Locked theme (`Catppuccin Mocha`)
+- `CursorBlink false`
+- Generous settle times for Bun cold-start (~3s)
+- No reliance on real WordPress sites — uses `--help` and local-only commands
+
+## GIF Optimization
+
+Raw VHS GIFs are 10–20 MB. The driver automatically runs `gifsicle -O3` (lossless
+inter-frame optimization) bringing them down 20–30× with zero quality loss. If
+gifsicle is missing, it warns but continues with the unoptimized file.
+
+## Tips
+
+- **Stills:** generous sleep before `Screenshot` — you only get one frame
+- **GIFs:** keep it short, one story per demo, end on the UI (no trailing quit)
+- **Sizing:** bump `fontSize` in the recipe to make text bigger; don't shrink the canvas
+- **Debugging:** check `bin/screenshot/out/` for raw output; run VHS directly on a generated `.tape`

--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -1,0 +1,443 @@
+/**
+ * Screenshot recipe catalog.
+ *
+ * Each recipe describes one scene to capture. The driver reads this list,
+ * builds a VHS tape from each, runs it, and optimizes the output.
+ *
+ * Naming convention:
+ *   - `ui-*`   → still PNG (feature shots, docs)
+ *   - `demo-*` → motion GIF (workflows in action, marketing)
+ */
+
+export type Action =
+  | { kind: 'type'; text: string; noEnter?: boolean }
+  | { kind: 'key'; key: string; count?: number }
+  | { kind: 'sleep'; ms: number };
+
+export type Recipe = {
+  /** Unique name — becomes the output filename (without extension). */
+  name: string;
+  /** Human description (shown by --list). */
+  description: string;
+  /** The localpress command to run (first command typed). */
+  command: string;
+  /** Keystrokes/sleeps after the command launches. */
+  actions?: Action[];
+  /** Font size in px (default 20). Controls capture scale. */
+  fontSize?: number;
+  /** Canvas height in px (default 600). Use 800+ for tall TUI apps. */
+  height?: number;
+  /** Typing speed in ms between chars (default 30). Lower = faster. */
+  typingSpeed?: number;
+  /** VHS theme name (default "Catppuccin Mocha"). */
+  theme?: string;
+  /** true → motion GIF; false/absent → still PNG. */
+  emitGif?: boolean;
+  /** GIF: total settle before first action (ms). Still: settle before Screenshot (ms). */
+  settleMs?: number;
+  /** Extra env vars to set in the VHS shell. */
+  env?: Record<string, string>;
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// STILLS — Feature shots for README, docs, marketing site
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const STILLS: Recipe[] = [
+  // ─── Real command output (visually rich) ──────────────────────────────────
+
+  {
+    name: 'ui-doctor',
+    description: 'Doctor output showing capability matrix with all green checkmarks',
+    command: 'localpress doctor',
+    settleMs: 6000,
+  },
+
+  {
+    name: 'ui-stats',
+    description: 'Stats dashboard showing savings, format breakdown, and recent ops',
+    command: 'localpress stats',
+    settleMs: 4000,
+  },
+
+  {
+    name: 'ui-list',
+    description: 'Media library listing with file details (real site data)',
+    command: 'localpress list --limit 15',
+    settleMs: 4000,
+  },
+
+  {
+    name: 'ui-history',
+    description: 'Time-machine history showing undo sessions',
+    command: 'localpress history',
+    settleMs: 6000,
+  },
+
+  // ─── Interactive browser (the TUI app) ────────────────────────────────────
+
+  {
+    name: 'ui-browser-list',
+    description: 'Interactive media browser — main list view with sidebar',
+    command: 'localpress list -i',
+    settleMs: 6000,
+    height: 800,
+    // Navigate down a few items to show the cursor + selection UI
+    actions: [
+      { kind: 'key', key: 'Down', count: 3 },
+      { kind: 'sleep', ms: 2000 },
+    ],
+  },
+
+  {
+    name: 'ui-browser-details',
+    description: 'Interactive browser — detail overlay showing full metadata',
+    command: 'localpress list -i',
+    settleMs: 6000,
+    height: 800,
+    actions: [
+      { kind: 'key', key: 'Down', count: 2 },
+      { kind: 'sleep', ms: 1000 },
+      { kind: 'key', key: 'Enter' }, // Open detail view
+      { kind: 'sleep', ms: 6000 }, // Extra time: API call + render
+    ],
+  },
+
+  {
+    name: 'ui-browser-optimize',
+    description: 'Interactive browser — optimize settings overlay (quality/format/keep)',
+    command: 'localpress list -i',
+    settleMs: 6000,
+    height: 800,
+    actions: [
+      { kind: 'key', key: 'Down', count: 4 },
+      { kind: 'sleep', ms: 2000 },
+      { kind: 'type', text: 'o', noEnter: true }, // Open optimize overlay
+      { kind: 'sleep', ms: 4000 }, // Extra time for overlay to fully render
+    ],
+  },
+
+  {
+    name: 'ui-browser-convert',
+    description: 'Interactive browser — convert format picker overlay',
+    command: 'localpress list -i',
+    settleMs: 6000,
+    height: 800,
+    actions: [
+      { kind: 'key', key: 'Down', count: 3 },
+      { kind: 'sleep', ms: 2000 },
+      { kind: 'type', text: 'c', noEnter: true }, // Open convert overlay
+      { kind: 'sleep', ms: 4000 },
+    ],
+  },
+
+  {
+    name: 'ui-browser-resize',
+    description: 'Interactive browser — resize dimension input overlay',
+    command: 'localpress list -i',
+    settleMs: 6000,
+    height: 800,
+    actions: [
+      { kind: 'key', key: 'Down', count: 2 },
+      { kind: 'sleep', ms: 2000 },
+      { kind: 'type', text: 's', noEnter: true }, // Open resize overlay
+      { kind: 'sleep', ms: 2000 },
+      { kind: 'type', text: '1024', noEnter: true }, // Type a width value
+      { kind: 'sleep', ms: 2000 },
+    ],
+  },
+
+  {
+    name: 'ui-browser-search',
+    description: 'Interactive browser — search/filter mode narrowing results',
+    command: 'localpress list -i',
+    settleMs: 6000,
+    height: 800,
+    actions: [
+      { kind: 'type', text: '/', noEnter: true }, // Open search
+      { kind: 'sleep', ms: 500 },
+      { kind: 'type', text: 'featured', noEnter: true }, // Type search query
+      { kind: 'sleep', ms: 2000 },
+    ],
+  },
+
+  {
+    name: 'ui-browser-multiselect',
+    description: 'Interactive browser — multi-select mode with items checked',
+    command: 'localpress list -i',
+    settleMs: 6000,
+    height: 800,
+    actions: [
+      { kind: 'key', key: 'Down' },
+      { kind: 'key', key: 'Space' }, // Select item 1
+      { kind: 'key', key: 'Space' }, // Select item 2
+      { kind: 'key', key: 'Space' }, // Select item 3
+      { kind: 'key', key: 'Down', count: 2 },
+      { kind: 'key', key: 'Space' }, // Select item 6
+      { kind: 'sleep', ms: 2000 },
+    ],
+  },
+
+  // ─── Help screens (reference/docs) ────────────────────────────────────────
+
+  {
+    name: 'ui-help',
+    description: 'Main help screen — all 38+ commands at a glance',
+    command: 'localpress --help',
+    settleMs: 3000,
+    fontSize: 16, // Smaller font to fit more commands on screen
+  },
+
+  {
+    name: 'ui-optimize-flags',
+    description: 'Optimize command flags — shows the depth of control available',
+    command: 'localpress optimize --help',
+    settleMs: 3000,
+  },
+
+  {
+    name: 'ui-audit-flags',
+    description: 'Audit checks overview — shows 10 different audit types',
+    command: 'localpress audit --help',
+    settleMs: 3000,
+  },
+];
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// MOTION GIFs — Workflows in action for hero sections and feature showcases
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const GIFS: Recipe[] = [
+  // ─── Interactive browser workflows (the star of the show) ─────────────────
+
+  {
+    name: 'demo-browser-navigate',
+    description: 'Interactive browser: browse items → open details → return to list',
+    command: 'localpress list -i',
+    emitGif: true,
+    settleMs: 4000,
+    height: 800,
+    actions: [
+      { kind: 'sleep', ms: 1500 },
+      { kind: 'key', key: 'Down', count: 3 },
+      { kind: 'sleep', ms: 1200 },
+      { kind: 'key', key: 'Down', count: 2 },
+      { kind: 'sleep', ms: 1500 },
+      { kind: 'key', key: 'Enter' }, // Open detail view
+      { kind: 'sleep', ms: 5000 }, // Hold on details (API fetch + read)
+      { kind: 'type', text: ' ', noEnter: true }, // Close details (any key)
+      { kind: 'sleep', ms: 1500 },
+      { kind: 'key', key: 'Down', count: 2 },
+      { kind: 'sleep', ms: 2000 },
+    ],
+  },
+
+  {
+    name: 'demo-browser-actions-tour',
+    description: 'Interactive browser: navigate → optimize overlay → cancel → convert picker',
+    command: 'localpress list -i',
+    emitGif: true,
+    settleMs: 3000,
+    height: 800,
+    actions: [
+      { kind: 'sleep', ms: 1000 },
+      { kind: 'key', key: 'Down', count: 3 },
+      { kind: 'sleep', ms: 800 },
+      // Open optimize overlay
+      { kind: 'type', text: 'o', noEnter: true },
+      { kind: 'sleep', ms: 2500 },
+      { kind: 'key', key: 'Escape' }, // Cancel
+      { kind: 'sleep', ms: 1200 },
+      // Open convert picker
+      { kind: 'type', text: 'c', noEnter: true },
+      { kind: 'sleep', ms: 2500 },
+      { kind: 'key', key: 'Escape' }, // Cancel
+      { kind: 'sleep', ms: 1200 },
+      // Open resize
+      { kind: 'type', text: 's', noEnter: true },
+      { kind: 'sleep', ms: 2000 },
+      { kind: 'key', key: 'Escape' }, // Cancel
+      { kind: 'sleep', ms: 1200 },
+    ],
+  },
+
+  {
+    name: 'demo-browser-details',
+    description: 'Interactive browser: select item → open detail view → close',
+    command: 'localpress list -i',
+    emitGif: true,
+    settleMs: 4000,
+    height: 800,
+    actions: [
+      { kind: 'sleep', ms: 2000 },
+      { kind: 'key', key: 'Down', count: 2 },
+      { kind: 'sleep', ms: 1000 },
+      { kind: 'key', key: 'Enter' }, // Open detail overlay
+      { kind: 'sleep', ms: 5000 }, // Hold on detail view (load + read time)
+      { kind: 'type', text: ' ', noEnter: true }, // Close detail (any key)
+      { kind: 'sleep', ms: 2000 },
+    ],
+  },
+
+  {
+    name: 'demo-browser-optimize-flow',
+    description: 'Interactive browser: select image → open optimize overlay → configure',
+    command: 'localpress list -i',
+    emitGif: true,
+    settleMs: 4000,
+    height: 800,
+    actions: [
+      { kind: 'sleep', ms: 2000 },
+      { kind: 'key', key: 'Down', count: 3 },
+      { kind: 'sleep', ms: 1000 },
+      { kind: 'type', text: 'o', noEnter: true }, // Open optimize settings
+      { kind: 'sleep', ms: 3000 },
+      { kind: 'key', key: 'Tab' }, // Move to quality field
+      { kind: 'sleep', ms: 800 },
+      { kind: 'type', text: '80', noEnter: true }, // Type quality
+      { kind: 'sleep', ms: 1500 },
+      { kind: 'key', key: 'Tab' }, // Move to format field
+      { kind: 'sleep', ms: 800 },
+      { kind: 'key', key: 'Space' }, // Cycle to webp
+      { kind: 'sleep', ms: 2500 },
+      { kind: 'key', key: 'Escape' }, // Cancel (don't actually run)
+      { kind: 'sleep', ms: 1500 },
+    ],
+  },
+
+  {
+    name: 'demo-browser-search',
+    description: 'Interactive browser: open search, filter by name, browse results',
+    command: 'localpress list -i',
+    emitGif: true,
+    settleMs: 4000,
+    height: 800,
+    actions: [
+      { kind: 'sleep', ms: 2000 },
+      { kind: 'type', text: '/', noEnter: true }, // Open search
+      { kind: 'sleep', ms: 800 },
+      { kind: 'type', text: 'screenshot', noEnter: true }, // Type search
+      { kind: 'sleep', ms: 2500 },
+      { kind: 'key', key: 'Down', count: 2 }, // Browse filtered results
+      { kind: 'sleep', ms: 2000 },
+      { kind: 'key', key: 'Escape' }, // Clear search
+      { kind: 'sleep', ms: 2000 },
+    ],
+  },
+
+  {
+    name: 'demo-browser-multiselect',
+    description: 'Interactive browser: multi-select items for bulk operations',
+    command: 'localpress list -i',
+    emitGif: true,
+    settleMs: 4000,
+    height: 800,
+    actions: [
+      { kind: 'sleep', ms: 2000 },
+      { kind: 'key', key: 'Down' },
+      { kind: 'key', key: 'Space' }, // Select 1
+      { kind: 'sleep', ms: 600 },
+      { kind: 'key', key: 'Space' }, // Select 2
+      { kind: 'sleep', ms: 600 },
+      { kind: 'key', key: 'Space' }, // Select 3
+      { kind: 'sleep', ms: 600 },
+      { kind: 'key', key: 'Down', count: 2 },
+      { kind: 'key', key: 'Space' }, // Select another
+      { kind: 'sleep', ms: 2500 },
+      { kind: 'key', key: 'Escape' }, // Clear selection
+      { kind: 'sleep', ms: 1500 },
+    ],
+  },
+
+  {
+    name: 'demo-browser-convert',
+    description: 'Interactive browser: open convert format picker → choose WebP',
+    command: 'localpress list -i',
+    emitGif: true,
+    settleMs: 4000,
+    height: 800,
+    actions: [
+      { kind: 'sleep', ms: 2000 },
+      { kind: 'key', key: 'Down', count: 4 },
+      { kind: 'sleep', ms: 1000 },
+      { kind: 'type', text: 'c', noEnter: true }, // Open convert
+      { kind: 'sleep', ms: 3000 }, // Show format picker
+      { kind: 'type', text: 'w', noEnter: true }, // Choose WebP
+      { kind: 'sleep', ms: 3000 }, // Show quality input
+      { kind: 'key', key: 'Escape' }, // Back out
+      { kind: 'sleep', ms: 1000 },
+      { kind: 'key', key: 'Escape' }, // Close overlay
+      { kind: 'sleep', ms: 1500 },
+    ],
+  },
+
+  // ─── CLI workflow demos ───────────────────────────────────────────────────
+
+  {
+    name: 'demo-doctor-to-list',
+    description: 'Run doctor → healthy site → then list media (shows the workflow)',
+    command: 'localpress doctor',
+    emitGif: true,
+    settleMs: 1500,
+    actions: [
+      { kind: 'sleep', ms: 4000 }, // let doctor output fully render
+      { kind: 'type', text: 'localpress list --limit 10' },
+      { kind: 'sleep', ms: 4000 }, // let list render
+    ],
+  },
+
+  {
+    name: 'demo-stats-overview',
+    description: 'Stats command rendering the full dashboard with savings',
+    command: 'localpress stats',
+    emitGif: true,
+    settleMs: 1500,
+    actions: [
+      { kind: 'sleep', ms: 5000 }, // hold on the full dashboard
+    ],
+  },
+
+  {
+    name: 'demo-optimize-dry-run',
+    description: 'Optimize --all --dry-run showing what localpress would do',
+    command: 'localpress optimize --all --dry-run',
+    emitGif: true,
+    settleMs: 1500,
+    actions: [{ kind: 'sleep', ms: 6000 }],
+  },
+
+  {
+    name: 'demo-history-undo',
+    description: 'History list → shows time-machine sessions available for undo',
+    command: 'localpress history',
+    emitGif: true,
+    settleMs: 1500,
+    actions: [
+      { kind: 'sleep', ms: 4000 }, // hold on history list
+      { kind: 'type', text: 'localpress undo --help' },
+      { kind: 'sleep', ms: 3000 }, // show undo options
+    ],
+  },
+
+  {
+    name: 'demo-full-workflow',
+    description: 'Hero GIF: doctor → list → stats (the full localpress experience)',
+    command: 'localpress doctor',
+    emitGif: true,
+    settleMs: 1500,
+    fontSize: 18,
+    actions: [
+      { kind: 'sleep', ms: 3500 }, // let doctor output render
+      { kind: 'type', text: 'localpress list --limit 5' },
+      { kind: 'sleep', ms: 4000 }, // let list render
+      { kind: 'type', text: 'localpress stats' },
+      { kind: 'sleep', ms: 4000 }, // hold on stats
+    ],
+  },
+];
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Export all recipes
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export const RECIPES: Recipe[] = [...STILLS, ...GIFS];

--- a/bin/screenshot/screenshot.ts
+++ b/bin/screenshot/screenshot.ts
@@ -1,0 +1,251 @@
+#!/usr/bin/env bun
+/**
+ * Screenshot driver — generates VHS tapes, runs them, optimizes output.
+ *
+ * Usage:
+ *   bun run bin/screenshot/screenshot.ts              # all recipes
+ *   bun run bin/screenshot/screenshot.ts --list       # list recipes
+ *   bun run bin/screenshot/screenshot.ts --recipe X   # single recipe
+ *   bun run bin/screenshot/screenshot.ts --stills     # only PNGs
+ *   bun run bin/screenshot/screenshot.ts --gifs       # only GIFs
+ */
+
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+import { RECIPES, type Recipe } from './recipes.ts';
+import { buildTape } from './tape.ts';
+
+// ─── Paths ──────────────────────────────────────────────────────────────────
+
+const SCRIPT_DIR = dirname(new URL(import.meta.url).pathname);
+const PROJECT_ROOT = resolve(SCRIPT_DIR, '../..');
+const OUT_DIR = resolve(SCRIPT_DIR, 'out');
+const TAPES_DIR = resolve(SCRIPT_DIR, 'tapes');
+const DEST_DIR = resolve(PROJECT_ROOT, '.www/public/screenshots');
+
+// The localpress entrypoint directory (so VHS shell can find the binary)
+const LOCALPRESS_BIN_DIR = resolve(PROJECT_ROOT, 'node_modules/.bin');
+
+// ─── CLI args ───────────────────────────────────────────────────────────────
+
+const { values } = parseArgs({
+  options: {
+    list: { type: 'boolean', default: false },
+    recipe: { type: 'string' },
+    stills: { type: 'boolean', default: false },
+    gifs: { type: 'boolean', default: false },
+    'skip-optimize': { type: 'boolean', default: false },
+    'dry-run': { type: 'boolean', default: false },
+  },
+  strict: true,
+});
+
+// ─── List mode ──────────────────────────────────────────────────────────────
+
+if (values.list) {
+  console.log('\nAvailable recipes:\n');
+  const maxName = Math.max(...RECIPES.map((r) => r.name.length));
+  for (const r of RECIPES) {
+    const type = r.emitGif ? '🎬 GIF' : '📸 PNG';
+    console.log(`  ${r.name.padEnd(maxName)}  ${type}  ${r.description}`);
+  }
+  console.log(`\n  Total: ${RECIPES.length} recipes\n`);
+  process.exit(0);
+}
+
+// ─── Filter recipes ─────────────────────────────────────────────────────────
+
+let recipes: Recipe[] = RECIPES;
+
+if (values.recipe) {
+  const found = RECIPES.find((r) => r.name === values.recipe);
+  if (!found) {
+    console.error(`❌ Unknown recipe: "${values.recipe}"`);
+    console.error(`   Available: ${RECIPES.map((r) => r.name).join(', ')}`);
+    process.exit(1);
+  }
+  recipes = [found];
+} else if (values.stills) {
+  recipes = RECIPES.filter((r) => !r.emitGif);
+} else if (values.gifs) {
+  recipes = RECIPES.filter((r) => r.emitGif === true);
+}
+
+// ─── Ensure directories ─────────────────────────────────────────────────────
+
+mkdirSync(OUT_DIR, { recursive: true });
+mkdirSync(TAPES_DIR, { recursive: true });
+mkdirSync(DEST_DIR, { recursive: true });
+
+// ─── Check dependencies ─────────────────────────────────────────────────────
+
+async function which(cmd: string): Promise<boolean> {
+  const proc = Bun.spawn(['which', cmd], { stdout: 'pipe', stderr: 'pipe' });
+  await proc.exited;
+  return proc.exitCode === 0;
+}
+
+async function checkDeps(): Promise<void> {
+  if (!(await which('vhs'))) {
+    console.error('❌ VHS not found. Install: brew install vhs');
+    process.exit(1);
+  }
+  if (!(await which('gifsicle'))) {
+    console.warn('⚠️  gifsicle not found — GIFs will not be optimized.');
+    console.warn('   Install: brew install gifsicle');
+  }
+}
+
+// ─── Run a single recipe ────────────────────────────────────────────────────
+
+async function runRecipe(recipe: Recipe): Promise<void> {
+  const isGif = recipe.emitGif === true;
+  const ext = isGif ? 'gif' : 'png';
+  const outputFile = `${recipe.name}.${ext}`;
+
+  console.log(`\n${'─'.repeat(60)}`);
+  console.log(`${isGif ? '🎬' : '📸'} ${recipe.name} — ${recipe.description}`);
+  console.log(`${'─'.repeat(60)}`);
+
+  // 1. Build the tape
+  const tape = buildTape(recipe, { localPressBin: LOCALPRESS_BIN_DIR });
+  const tapeFile = resolve(TAPES_DIR, `${recipe.name}.tape`);
+  await Bun.write(tapeFile, tape);
+
+  if (values['dry-run']) {
+    console.log(`  📄 Tape written: ${tapeFile}`);
+    console.log('  (dry-run — skipping VHS render)');
+    return;
+  }
+
+  // 2. Run VHS
+  console.log('  ▶ Running VHS...');
+  const vhsProc = Bun.spawn(['vhs', tapeFile], {
+    cwd: OUT_DIR,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  const exitCode = await vhsProc.exited;
+  const stderr = await new Response(vhsProc.stderr).text();
+  if (exitCode !== 0) {
+    console.error(`  ❌ VHS failed (exit ${exitCode}):`);
+    console.error(`     ${stderr.trim()}`);
+    return;
+  }
+  if (stderr.trim()) {
+    // VHS always prints "File: ..." to stderr — only show other warnings
+    const meaningful = stderr
+      .split('\n')
+      .filter((l) => l.trim() && !l.startsWith('File:'))
+      .join('\n');
+    if (meaningful) {
+      console.log(`  ⚠️  VHS: ${meaningful.trim().split('\n')[0]}`);
+    }
+  }
+
+  const rawOutput = resolve(OUT_DIR, outputFile);
+
+  // VHS may flush the file slightly after process exit — wait briefly if needed
+  let found = existsSync(rawOutput);
+  if (!found) {
+    for (let i = 0; i < 5; i++) {
+      await Bun.sleep(500);
+      found = existsSync(rawOutput);
+      if (found) break;
+    }
+  }
+
+  if (!found) {
+    // Retry once — VHS occasionally fails to write Screenshot output
+    console.log('  ⟳ Retrying VHS (output not found on first attempt)...');
+    const retryProc = Bun.spawn(['vhs', tapeFile], {
+      cwd: OUT_DIR,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    await retryProc.exited;
+    // Wait for filesystem
+    for (let i = 0; i < 10; i++) {
+      await Bun.sleep(500);
+      found = existsSync(rawOutput);
+      if (found) break;
+    }
+  }
+
+  if (!found) {
+    console.error(`  ❌ Expected output not found: ${rawOutput}`);
+    return;
+  }
+
+  // 3. Optimize GIFs losslessly
+  if (isGif && !values['skip-optimize']) {
+    await optimizeGif(rawOutput);
+  }
+
+  // 4. Copy to destination
+  const destFile = resolve(DEST_DIR, outputFile);
+  const file = Bun.file(rawOutput);
+  await Bun.write(destFile, file);
+
+  const sizeKb = ((await file.arrayBuffer()).byteLength / 1024).toFixed(1);
+  console.log(`  ✅ ${outputFile} (${sizeKb} KB) → ${destFile}`);
+}
+
+// ─── GIF optimization ───────────────────────────────────────────────────────
+
+async function optimizeGif(filePath: string): Promise<void> {
+  if (!(await which('gifsicle'))) {
+    console.log('  ⚠️  Skipping GIF optimization (gifsicle not installed)');
+    return;
+  }
+
+  const before = Bun.file(filePath);
+  const beforeSize = (await before.arrayBuffer()).byteLength;
+
+  console.log('  🗜️  Optimizing with gifsicle -O3...');
+  const proc = Bun.spawn(['gifsicle', '-O3', '--batch', filePath], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  await proc.exited;
+
+  const after = Bun.file(filePath);
+  const afterSize = (await after.arrayBuffer()).byteLength;
+  const ratio = ((1 - afterSize / beforeSize) * 100).toFixed(1);
+  console.log(
+    `     ${(beforeSize / 1024).toFixed(0)} KB → ${(afterSize / 1024).toFixed(0)} KB (${ratio}% reduction)`,
+  );
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  console.log('🎥 localpress screenshot pipeline');
+  console.log(`   Recipes: ${recipes.length} | Output: ${OUT_DIR}`);
+
+  await checkDeps();
+
+  const startTime = Date.now();
+
+  for (const recipe of recipes) {
+    await runRecipe(recipe);
+    // Small cooldown between recipes to avoid VHS process contention
+    await Bun.sleep(1000);
+  }
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.log(`\n✨ Done! ${recipes.length} capture(s) in ${elapsed}s`);
+  console.log(`   Output: ${DEST_DIR}\n`);
+
+  // Cleanup generated tapes (keep out/ for debugging)
+  if (!values['dry-run']) {
+    rmSync(TAPES_DIR, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/bin/screenshot/tape.ts
+++ b/bin/screenshot/tape.ts
@@ -1,0 +1,110 @@
+/**
+ * Tape builder — transforms a Recipe into a VHS .tape string.
+ *
+ * All determinism controls live here so individual recipes stay declarative.
+ */
+
+import type { Recipe } from './recipes.ts';
+
+const DEFAULT_FONT_SIZE = 20;
+const DEFAULT_THEME = 'Catppuccin Mocha';
+const DEFAULT_SETTLE_MS = 3000;
+const DEFAULT_TYPING_SPEED = 30;
+
+/**
+ * Build a VHS tape string from a recipe.
+ *
+ * @param recipe - The scene to capture
+ * @param opts.localPressBin - Path to the localpress binary/entrypoint
+ */
+export function buildTape(recipe: Recipe, opts: { localPressBin: string }): string {
+  const lines: string[] = [];
+  const fontSize = recipe.fontSize ?? DEFAULT_FONT_SIZE;
+  const theme = recipe.theme ?? DEFAULT_THEME;
+  const settleMs = recipe.settleMs ?? DEFAULT_SETTLE_MS;
+  const typingSpeed = recipe.typingSpeed ?? DEFAULT_TYPING_SPEED;
+  const isGif = recipe.emitGif === true;
+
+  // --- Output declaration ---
+  if (isGif) {
+    lines.push(`Output "${recipe.name}.gif"`);
+  }
+  lines.push('');
+
+  // --- Settings block ---
+  lines.push('# --- Settings ---');
+  lines.push('Set Shell "bash"');
+  lines.push(`Set FontSize ${fontSize}`);
+  if (recipe.height) {
+    lines.push(`Set Height ${recipe.height}`);
+  }
+  lines.push('Set Padding 24');
+  lines.push(`Set Theme "${theme}"`);
+  lines.push('Set CursorBlink false');
+  lines.push(`Set TypingSpeed ${typingSpeed}ms`);
+  lines.push('');
+
+  // --- Hidden setup ---
+  lines.push('# --- Hidden setup (not recorded) ---');
+  lines.push('Hide');
+
+  // Forward PATH so localpress is available
+  lines.push(`Type "export PATH=${opts.localPressBin}:$PATH" Enter`);
+
+  // Extra env vars from the recipe
+  if (recipe.env) {
+    for (const [key, value] of Object.entries(recipe.env)) {
+      lines.push(`Type "export ${key}=${value}" Enter`);
+    }
+  }
+
+  lines.push('Type "clear" Enter');
+  lines.push('Sleep 500ms');
+  lines.push('Show');
+  lines.push('');
+
+  // --- The scene ---
+  lines.push('# --- Scene ---');
+  lines.push(`Type "${escapeForTape(recipe.command)}" Enter`);
+  lines.push(`Sleep ${settleMs}ms`);
+
+  // Actions (keystrokes, typing, sleeps)
+  if (recipe.actions) {
+    for (const action of recipe.actions) {
+      switch (action.kind) {
+        case 'type':
+          if (action.noEnter) {
+            lines.push(`Type "${escapeForTape(action.text)}"`);
+          } else {
+            lines.push(`Type "${escapeForTape(action.text)}" Enter`);
+          }
+          break;
+        case 'key':
+          if (action.count && action.count > 1) {
+            lines.push(`${action.key} ${action.count}`);
+          } else {
+            lines.push(action.key);
+          }
+          break;
+        case 'sleep':
+          lines.push(`Sleep ${action.ms}ms`);
+          break;
+      }
+    }
+  }
+
+  // --- Capture ---
+  if (!isGif) {
+    lines.push('');
+    lines.push(`Screenshot ${recipe.name}.png`);
+  }
+  // GIFs: no trailing quit — end on the last meaningful frame
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+/** Escape double quotes for VHS Type commands. */
+function escapeForTape(text: string): string {
+  return text.replace(/"/g, '\\"');
+}

--- a/docs/blog-post-v2.md
+++ b/docs/blog-post-v2.md
@@ -217,7 +217,7 @@ The full roadmap has 450+ ideas across 61 domains: [docs/roadmap-ideas.md](https
 
 ```bash
 # New install
-brew install gfargo/localpress/localpress
+brew install gfargo/tap/localpress
 
 # Upgrade existing
 brew upgrade localpress

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test": "bun test",
     "test:watch": "bun test --watch",
     "test:tarball": "bun test test/tarball/",
+    "screenshot": "bun run bin/screenshot/screenshot.ts",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",


### PR DESCRIPTION
## Screenshot & Demo GIF Pipeline

Adds `bin/screenshot/` — a deterministic, reproducible pipeline for generating marketing screenshots and demo GIFs using [Charm VHS](https://github.com/charmbracelet/vhs).

### What's in it

**26 recipes** (14 stills + 12 motion GIFs) covering:

- **Interactive browser TUI** (7 stills + 7 GIFs) — the star of the show:
  - Main list view with sidebar, detail overlay, optimize settings, convert picker, resize inputs, search/filter, multi-select, actions tour
- **CLI output** (4 stills + 5 GIFs) — doctor, stats, list, history, optimize dry-run, full workflow hero
- **Reference** (3 stills) — help screen, optimize flags, audit flags

### Architecture

```
bin/screenshot/
├── recipes.ts      # declarative scene catalog (data)
├── tape.ts         # recipe → VHS .tape (pure transform, determinism lives here)
├── screenshot.ts   # driver: tape → VHS → gifsicle optimize → sync to .www/
└── README.md       # usage docs
```

### Usage

```bash
bun run screenshot              # all 26 recipes
bun run screenshot -- --list    # list available
bun run screenshot -- --recipe demo-browser-navigate
bun run screenshot -- --stills  # PNGs only
bun run screenshot -- --gifs    # GIFs only
bun run screenshot -- --dry-run # generate tapes without rendering
```

### Key decisions

- **30ms typing speed** — snappy without being unreadable
- **800px height** for browser TUI recipes — gives ~33 terminal rows, no title jumping
- **Lossless GIF optimization** via `gifsicle -O3` built into the driver (20-30× reduction)
- **Retry mechanism** for VHS's intermittent Screenshot write race condition
- **1s cooldown** between sequential recipes to avoid VHS process contention
- Output lands in `.www/public/screenshots/` ready for the marketing site

### Prerequisites

```bash
brew install vhs gifsicle
```

### Not included

The generated screenshots/GIFs themselves are not committed — they're regenerated on demand via `bun run screenshot` and live in `.www/` which is gitignored.
