### PR TITLE
Trust & correctness release (v2.1.0): dry-run, undo, idempotency, reference safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-07-05
+
+Trust & correctness release — hardens the safety primitives (dry-run, undo,
+idempotency, reference tracking) surfaced by a full-codebase audit. No new
+command surface; every change makes an existing operation safer or more correct.
+
+### Fixed — data safety (critical)
+- **`references --update-to` no longer mutates the database under `--dry-run`**
+  (#89). The featured-image (`_thumbnail_id`) update previously ran
+  unconditionally; it is now gated and reports a count in dry-run mode.
+- **`references --update-to` block-ID rewrite is boundary-anchored** (#89) — a
+  regex-anchored replace scoped to `post_content` so rewriting attachment `12`
+  can no longer corrupt `123`. URL replacement now runs across all tables
+  (serialize-safe) instead of `wp_posts` only, resolves the real table prefix,
+  and reports partial-failure state.
+- **Global `--dry-run` is honored by `delete`, `posts delete`, `posts update`,
+  and `metadata`** (#90) via a shared `resolveDryRun` helper — these destructive
+  commands previously ignored it and executed for real.
+- **Animated GIF/WebP are preserved, not flattened** (#93). Multi-frame sources
+  stay animated for gif/webp targets and are skipped (with a warning) for
+  formats that can't hold animation, instead of being silently reduced to frame 1.
+- **SVG and other unencodable formats are skipped, not rasterized** (#94).
+  `optimize --all` filters to a MIME whitelist and the engine throws rather than
+  writing PNG bytes under a `.svg` name.
+- **Snapshots are written synchronously before the history row is committed**
+  (#92) — an interrupted run can no longer leave `undo` pointing at a missing
+  or truncated blob.
+
+### Fixed — correctness (high)
+- **`remove-bg` replace-in-place sets the PNG MIME/extension and regenerates
+  thumbnails** (#95) so thumbnails show the cutout and WordPress serves the
+  right content type.
+- **`remove-bg` batch no longer aborts on a per-item `getMedia` failure** (#96) —
+  failure recording is FK-safe and self-contained.
+- **`optimize --unoptimized` is filtered to compression operations** (#98), so a
+  `caption`/`classify`/`rename` pass no longer makes images look "already
+  optimized".
+- **jsquash encoder honors the raw buffer's `byteOffset`** (#100), fixing
+  out-of-bounds pixel reads that could corrupt output mid-bulk-run.
+- **REST reference scan finds Gutenberg embeds** (#101): posts are fetched with
+  `context=edit` and raw block content is scanned (with a `wp-image-<id>`
+  rendered fallback). `getMedia` also returns raw fields so `tag`/`vision`
+  no longer flatten formatted captions.
+- **`delete` without `--force` returns actionable guidance** when a site lacks
+  `MEDIA_TRASH` (previously an opaque 501) (#102).
+
+### Fixed — robustness (medium)
+- **SQLite `busy_timeout` + conditional version stamp** (#114) so `watch` and a
+  foreground command sharing a site DB no longer crash with "database is locked".
+- **Config file is created `0600` atomically** (#118) — Application Passwords are
+  never briefly world-readable; a failed chmod now warns instead of being
+  swallowed. Site names are validated to reject path traversal.
+- **Zip Slip guard on `import`** (#107) rejects archive entries that resolve
+  outside the extraction directory.
+- **Transparent PNG → JPEG is flattened onto white** (not black), EXIF
+  orientation is always baked in (even when metadata is kept), and the
+  `--target-size` "at q=1" warning is only shown when a quality search ran.
+- **`posts update` can clear a field** with an explicit empty value.
+
 ## [2.0.0] - 2026-05-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localpress",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Local-compute WordPress media optimization. Your laptop, your library.",
   "license": "MIT",
   "author": "Griffen Fargo",

--- a/src/adapters/rest.ts
+++ b/src/adapters/rest.ts
@@ -145,7 +145,12 @@ export class RestAdapter implements WpBackend {
   }
 
   async getMedia(id: number): Promise<MediaItem> {
-    const raw = await this.request<WpMediaResponse>(this.apiUrl(`/media/${id}`));
+    // Request context=edit so title/caption/description come back as `.raw`
+    // (unrendered). Read-modify-write flows (tag/vision) must not round-trip
+    // through stripped, entity-encoded rendered HTML, which flattens captions.
+    const raw = await this.request<WpMediaResponse>(
+      this.apiUrl(`/media/${id}`, { context: 'edit' }),
+    );
     return mapWpMediaToItem(raw);
   }
 
@@ -205,9 +210,22 @@ export class RestAdapter implements WpBackend {
     if (options?.force) {
       params.force = 'true';
     }
-    await this.request<unknown>(this.apiUrl(`/media/${id}`, params), {
-      method: 'DELETE',
-    });
+    try {
+      await this.request<unknown>(this.apiUrl(`/media/${id}`, params), {
+        method: 'DELETE',
+      });
+    } catch (err) {
+      // Stock WordPress can't trash attachments unless MEDIA_TRASH is defined,
+      // so a non-force delete returns 501 rest_trash_not_supported. Translate
+      // that into actionable guidance instead of an opaque REST error.
+      const message = err instanceof Error ? err.message : String(err);
+      if (!options?.force && /rest_trash_not_supported|\b501\b/.test(message)) {
+        throw new Error(
+          `Attachment ${id} cannot be moved to trash: this WordPress site does not have MEDIA_TRASH enabled. Re-run with --force to delete it permanently (localpress captures an undo snapshot first).`,
+        );
+      }
+      throw err;
+    }
   }
 
   // Server-side ops -----------------------------------------------------------
@@ -257,40 +275,28 @@ export class RestAdapter implements WpBackend {
     }
 
     // 2. Gutenberg block references: search content for wp:image {"id":N}.
+    //    The `wp:image` block marker lives in the RAW block comment, which is
+    //    stripped from rendered HTML — so we must request context=edit to get
+    //    content.raw. Without it, embedded images are never found.
     for (const postType of ['posts', 'pages'] as const) {
       const posts = await this.paginateAll<WpPostResponse>(
         this.apiUrl(`/${postType}`, {
           per_page: 100,
+          context: 'edit',
           _fields: 'id,title,type,content',
         }),
       );
 
       for (const post of posts) {
-        const content = post.content?.rendered ?? post.content?.raw ?? '';
-        const occurrences = countBlockReferences(content, id);
+        const occurrences = countPostImageReferences(post, id);
         if (occurrences > 0) {
-          // Avoid duplicating if we already have a featured-image ref for this post.
-          const alreadyReferenced = references.some(
-            (r) => r.postId === post.id && r.type === 'featured-image',
-          );
-          if (!alreadyReferenced) {
-            references.push({
-              type: 'gutenberg-block',
-              postId: post.id,
-              postTitle: renderTitle(post.title),
-              postType: post.type,
-              occurrences,
-            });
-          } else {
-            // Add as a separate gutenberg-block reference anyway — both are valid.
-            references.push({
-              type: 'gutenberg-block',
-              postId: post.id,
-              postTitle: renderTitle(post.title),
-              postType: post.type,
-              occurrences,
-            });
-          }
+          references.push({
+            type: 'gutenberg-block',
+            postId: post.id,
+            postTitle: renderTitle(post.title),
+            postType: post.type,
+            occurrences,
+          });
         }
       }
     }
@@ -453,8 +459,23 @@ function stripHtml(html: string | undefined): string | undefined {
 }
 
 /**
- * Count occurrences of a Gutenberg block referencing a specific attachment ID.
- * Matches patterns like: wp:image {"id":123  or  "id": 123
+ * Count how many times a post references a specific attachment ID via a
+ * Gutenberg block.
+ *
+ * Prefers the raw block content (`content.raw`, available with context=edit),
+ * where blocks carry an explicit `"id":N` attribute. Falls back to the rendered
+ * HTML's `wp-image-<id>` class when raw content isn't available (e.g. the auth
+ * user lacks edit rights), so embeds are still detected.
+ */
+function countPostImageReferences(post: WpPostResponse, attachmentId: number): number {
+  const raw = post.content?.raw;
+  if (raw) return countBlockReferences(raw, attachmentId);
+  return countRenderedImageReferences(post.content?.rendered ?? '', attachmentId);
+}
+
+/**
+ * Count occurrences of a Gutenberg block referencing a specific attachment ID
+ * in RAW block content. Matches patterns like: wp:image {"id":123 or "id": 123
  */
 function countBlockReferences(content: string, attachmentId: number): number {
   // Match wp:image/gallery/cover/media-text blocks that reference this ID.
@@ -463,5 +484,15 @@ function countBlockReferences(content: string, attachmentId: number): number {
     'g',
   );
   const matches = content.match(pattern);
+  return matches?.length ?? 0;
+}
+
+/**
+ * Fallback for rendered HTML: WordPress emits `class="... wp-image-<id> ..."`
+ * on `<img>` tags produced from image blocks.
+ */
+function countRenderedImageReferences(html: string, attachmentId: number): number {
+  const pattern = new RegExp(`wp-image-${attachmentId}\\b`, 'g');
+  const matches = html.match(pattern);
   return matches?.length ?? 0;
 }

--- a/src/adapters/ssh.ts
+++ b/src/adapters/ssh.ts
@@ -16,6 +16,17 @@ export interface SshExecResult {
 }
 
 /**
+ * POSIX shell-quote a value for safe interpolation into a remote command.
+ *
+ * Wraps in single quotes and escapes embedded single quotes via the `'\''`
+ * idiom, so filenames/paths/metadata containing spaces, quotes, `$`, backticks,
+ * or `;` can't break the command or inject shell execution.
+ */
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
  * Execute a command on a remote host via SSH.
  */
 export async function sshExec(ssh: SshConfig, command: string): Promise<SshExecResult> {

--- a/src/cli/commands/delete.ts
+++ b/src/cli/commands/delete.ts
@@ -27,7 +27,8 @@ import {
 } from '../../engine/history/index.ts';
 import { SiteDb } from '../../engine/state/db.ts';
 import { getConfigDir, getSiteDbPath, loadConfig, resolveActiveSite } from '../utils/config.ts';
-import { error, info, printJson } from '../utils/output.ts';
+import { error, info, printJson, warn } from '../utils/output.ts';
+import { resolveDryRun } from '../utils/run-mode.ts';
 
 interface DeleteResultRecord {
   id: number;
@@ -60,6 +61,22 @@ export function registerDeleteCommand(program: Command): void {
       const site = resolveActiveSite(config, parentOpts.site);
       const resolver = new AdapterResolver(site);
       const getAdapter = resolver.resolve('get');
+
+      // Deletion is destructive; honor an explicit --dry-run by previewing only.
+      const dryRun = resolveDryRun(parentOpts, false);
+      if (dryRun) {
+        warn(
+          `[dry-run] would delete ${ids.length} attachment(s); pass without --dry-run to execute:`,
+        );
+        for (const id of ids) {
+          info(`  would delete #${id}${options.force ? ' (permanent)' : ' (to trash)'}`);
+        }
+        if (parentOpts.json) {
+          printJson({ dryRun: true, force: Boolean(options.force), ids });
+        }
+        return;
+      }
+
       const deleteAdapter = resolver.resolve('delete');
 
       const db = SiteDb.init(getSiteDbPath(site.name));

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -365,10 +365,20 @@ async function extractZip(zipPath: string): Promise<ExtractedZip> {
   const files: string[] = [];
   let manifest: ExportManifest | null = null;
 
+  const { mkdirSync } = await import('node:fs');
+  const { dirname, resolve, sep } = await import('node:path');
+  const tempRoot = resolve(tempDir);
+
   for (const entry of entries) {
-    const destPath = join(tempDir, entry.path);
-    const { mkdirSync } = await import('node:fs');
-    mkdirSync(join(tempDir, entry.path.split('/').slice(0, -1).join('/')), { recursive: true });
+    // Zip Slip guard: reject entries that would resolve outside the temp dir
+    // (absolute paths or `../` traversal in a malicious archive).
+    const destPath = resolve(tempRoot, entry.path);
+    if (destPath !== tempRoot && !destPath.startsWith(tempRoot + sep)) {
+      warn(`Skipping unsafe archive entry outside extraction dir: ${entry.path}`);
+      continue;
+    }
+
+    mkdirSync(dirname(destPath), { recursive: true });
     await Bun.write(destPath, entry.data);
 
     if (entry.path === 'manifest.json') {

--- a/src/cli/commands/metadata.ts
+++ b/src/cli/commands/metadata.ts
@@ -27,7 +27,8 @@ import {
 } from '../../engine/history/index.ts';
 import { SiteDb } from '../../engine/state/db.ts';
 import { getConfigDir, getSiteDbPath, loadConfig, resolveActiveSite } from '../utils/config.ts';
-import { error, info, printJson } from '../utils/output.ts';
+import { error, info, printJson, warn } from '../utils/output.ts';
+import { resolveDryRun } from '../utils/run-mode.ts';
 
 interface MetadataResultRecord {
   id: number;
@@ -74,6 +75,17 @@ export function registerMetadataCommand(program: Command): void {
       const config = await loadConfig();
       const site = resolveActiveSite(config, parentOpts.site);
       const resolver = new AdapterResolver(site);
+
+      // Writing metadata mutates the live site; honor an explicit --dry-run.
+      if (resolveDryRun(parentOpts, false)) {
+        const fields = Object.keys(incoming).join(', ');
+        warn(`[dry-run] would set ${fields} on ${ids.length} attachment(s): ${ids.join(', ')}`);
+        if (parentOpts.json) {
+          printJson({ dryRun: true, ids, changes: incoming });
+        }
+        return;
+      }
+
       const getAdapter = resolver.resolve('get');
       const metaAdapter = resolver.resolve('update-meta');
 

--- a/src/cli/commands/optimize.ts
+++ b/src/cli/commands/optimize.ts
@@ -23,12 +23,27 @@ import {
   openSnapshotStore,
   resolveHistoryConfig,
 } from '../../engine/history/index.ts';
-import { optimizeImage } from '../../engine/image/optimize.ts';
+import {
+  AnimatedImageError,
+  UnsupportedFormatError,
+  optimizeImage,
+} from '../../engine/image/optimize.ts';
 import type { ImageFormat, OptimizeOptions } from '../../engine/image/types.ts';
 import { SiteDb } from '../../engine/state/db.ts';
 import { getConfigDir, getSiteDbPath, loadConfig, resolveActiveSite } from '../utils/config.ts';
 import { error, info, printJson, warn } from '../utils/output.ts';
 import { getCachedClassification } from './classify.ts';
+
+/** Source MIME types the optimize pipeline can safely handle. Anything else
+ * (e.g. image/svg+xml) is skipped so it can't be rasterized in place. */
+const OPTIMIZABLE_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+  'image/avif',
+  'image/gif',
+]);
 
 interface OptimizeResultRecord {
   id: number;
@@ -352,11 +367,13 @@ export function registerOptimizeCommand(program: Command): void {
           items = items.filter((item) => (item.sizeBytes ?? 0) >= options.largerThan);
         }
 
-        // Apply --unoptimized filter.
+        // Apply --unoptimized filter. Only compression operations count as
+        // "optimized" — a caption/classify/rename pass must not exclude an
+        // image that has never actually been compressed.
         if (options.unoptimized) {
           try {
             const db = SiteDb.init(getSiteDbPath(site.name));
-            const processed = db.listProcessedWpIds(site.name);
+            const processed = db.listProcessedWpIds(site.name, ['optimize', 'convert', 'resize']);
             items = items.filter((item) => !processed.has(item.id));
             db.close();
           } catch {
@@ -364,8 +381,9 @@ export function registerOptimizeCommand(program: Command): void {
           }
         }
 
-        // Only process images.
-        items = items.filter((item) => item.mimeType?.startsWith('image/'));
+        // Only process image types the engine can safely re-encode. SVG and
+        // other vector/unknown types are skipped rather than rasterized.
+        items = items.filter((item) => OPTIMIZABLE_MIME_TYPES.has(item.mimeType ?? ''));
       }
 
       if (items.length === 0) {
@@ -475,8 +493,12 @@ export function registerOptimizeCommand(program: Command): void {
           const resultHash = createHash('sha256').update(result.bytes).digest('hex');
           const durationMs = Date.now() - startTime;
 
-          // Skip if the result is larger than the source (unless format conversion was requested).
-          if (result.bytes.length >= sourceBytes.length && !options.to) {
+          // Skip if the result is larger than the source, unless a real format
+          // conversion was requested (via --to, a profile, or a smart default).
+          const conversionRequested = Boolean(
+            perItemOpts.toFormat && perItemOpts.toFormat !== result.before.format,
+          );
+          if (result.bytes.length >= sourceBytes.length && !conversionRequested) {
             info(
               `    ↳ Skipped (optimized size ${formatBytes(result.bytes.length)} ≥ original ${formatBytes(sourceBytes.length)}).`,
             );
@@ -571,9 +593,14 @@ export function registerOptimizeCommand(program: Command): void {
             info(`      Steps: ${result.appliedSteps.join(' → ')}`);
           }
           if (options.targetSize && result.after.sizeBytes > options.targetSize) {
+            // Only claim "at q=1" when a quality search actually ran; PNG/GIF
+            // (and lossless modes) don't have a quality knob to turn down.
+            const detail =
+              result.finalQuality !== undefined
+                ? `smallest achievable is ${formatBytes(result.after.sizeBytes)} at q=1`
+                : `target-size is not supported for ${result.after.format} — try --to webp`;
             warn(
-              `    ⚠ Could not reach target size ${formatBytes(options.targetSize)}; ` +
-                `smallest achievable is ${formatBytes(result.after.sizeBytes)} at q=1.`,
+              `    ⚠ Could not reach target size ${formatBytes(options.targetSize)}; ${detail}.`,
             );
           }
 
@@ -611,6 +638,12 @@ export function registerOptimizeCommand(program: Command): void {
             finalQuality: result.finalQuality,
           });
         } catch (err) {
+          // Animated-source and unsupported-format cases are deliberate skips,
+          // not failures — never flatten an animation or rasterize a vector.
+          if (err instanceof AnimatedImageError || err instanceof UnsupportedFormatError) {
+            warn(`    ↳ Skipped #${item.id} (${item.filename}): ${err.message}`);
+            continue;
+          }
           const message = err instanceof Error ? err.message : String(err);
           error(`    ✗ #${item.id}: ${message}`);
           failures++;

--- a/src/cli/commands/posts.ts
+++ b/src/cli/commands/posts.ts
@@ -8,7 +8,8 @@
 import { readFileSync } from 'node:fs';
 import type { Command } from 'commander';
 import { loadConfig, resolveActiveSite } from '../utils/config.ts';
-import { error, info, printJson } from '../utils/output.ts';
+import { error, info, printJson, warn } from '../utils/output.ts';
+import { resolveDryRun } from '../utils/run-mode.ts';
 
 interface WpPost {
   id: number;
@@ -328,12 +329,14 @@ export function registerPostsCommand(program: Command): void {
       const url = `${site.url.replace(/\/+$/, '')}/wp-json/wp/v2${endpoint}/${id}`;
       const auth = `Basic ${btoa(`${site.username}:${site.appPassword}`)}`;
 
+      // Use !== undefined so an explicit empty string (e.g. --excerpt "") can
+      // clear a field, rather than being silently dropped by a truthiness check.
       const body: Record<string, unknown> = {};
-      if (options.title) body.title = options.title;
-      if (content) body.content = content;
-      if (options.status) body.status = options.status;
-      if (options.slug) body.slug = options.slug;
-      if (options.excerpt) body.excerpt = options.excerpt;
+      if (options.title !== undefined) body.title = options.title;
+      if (content !== undefined) body.content = content;
+      if (options.status !== undefined) body.status = options.status;
+      if (options.slug !== undefined) body.slug = options.slug;
+      if (options.excerpt !== undefined) body.excerpt = options.excerpt;
       if (options.featuredImage) body.featured_media = options.featuredImage;
       if (options.category) body.categories = options.category.split(',').map(Number);
       if (options.tag) body.tags = options.tag.split(',').map(Number);
@@ -341,6 +344,14 @@ export function registerPostsCommand(program: Command): void {
       if (Object.keys(body).length === 0) {
         error('At least one field to update is required (--title, --content, --status, etc.).');
         process.exit(2);
+      }
+
+      if (resolveDryRun(parentOpts, false)) {
+        warn(`[dry-run] would update ${options.type} #${id}: ${Object.keys(body).join(', ')}`);
+        if (parentOpts.json) {
+          printJson({ dryRun: true, action: 'update', id, fields: body });
+        }
+        return;
       }
 
       try {
@@ -386,6 +397,16 @@ export function registerPostsCommand(program: Command): void {
       if (Number.isNaN(id)) {
         error('ID must be a valid integer.');
         process.exit(2);
+      }
+
+      if (resolveDryRun(parentOpts, false)) {
+        warn(
+          `[dry-run] would ${options.force ? 'permanently delete' : 'trash'} ${options.type} #${id}`,
+        );
+        if (parentOpts.json) {
+          printJson({ dryRun: true, action: options.force ? 'delete' : 'trash', id });
+        }
+        return;
       }
 
       const endpoint = typeEndpoint(options.type);

--- a/src/cli/commands/references.ts
+++ b/src/cli/commands/references.ts
@@ -8,10 +8,11 @@
 
 import type { Command } from 'commander';
 import { AdapterResolver } from '../../adapters/resolver.ts';
-import { sshExec } from '../../adapters/ssh.ts';
+import { shellQuote, sshExec } from '../../adapters/ssh.ts';
 import type { ReferenceScope } from '../../adapters/types.ts';
 import { loadConfig, resolveActiveSite } from '../utils/config.ts';
 import { error, info, printJson, warn } from '../utils/output.ts';
+import { resolveDryRun } from '../utils/run-mode.ts';
 
 export function registerReferencesCommand(program: Command): void {
   program
@@ -47,6 +48,7 @@ export function registerReferencesCommand(program: Command): void {
           error('--update-to requires WP-CLI over SSH. Configure SSH access for this site.');
           process.exit(6);
         }
+        const ssh = site.ssh;
 
         // Get the old and new attachment URLs.
         const getAdapter = resolver.resolve('get');
@@ -55,35 +57,67 @@ export function registerReferencesCommand(program: Command): void {
 
         info(`Rewriting references from #${id} → #${newId}...`);
 
-        const isDryRun = parentOpts.dryRun && !parentOpts.apply;
+        const isDryRun = resolveDryRun(parentOpts, false);
         const dryRunFlag = isDryRun ? '--dry-run' : '';
+        const cd = `cd ${shellQuote(ssh.wpPath)}`;
 
-        // 1. Update featured images (_thumbnail_id).
-        await sshExec(
-          site.ssh,
-          `cd ${site.ssh.wpPath} && wp db query "UPDATE wp_postmeta SET meta_value='${newId}' WHERE meta_key='_thumbnail_id' AND meta_value='${id}'" --allow-root`,
-        );
-        if (!isDryRun) {
+        // Fails the whole step loudly if a remote command errors, and reports
+        // which steps had already completed (this flow is not transactional).
+        const completed: string[] = [];
+        const run = async (label: string, command: string): Promise<string> => {
+          const res = await sshExec(ssh, `${cd} && ${command} --allow-root`);
+          if (res.exitCode !== 0) {
+            const applied = completed.length
+              ? `Already applied: ${completed.join(', ')} — the rewrite is now partial.`
+              : 'No changes were applied.';
+            throw new Error(
+              `${label} failed (exit ${res.exitCode}): ${res.stderr || res.stdout}\n${applied}`,
+            );
+          }
+          completed.push(label);
+          return res.stdout.trim();
+        };
+
+        // Resolve the real table prefix ($table_prefix may not be wp_).
+        const prefixRes = await sshExec(ssh, `${cd} && wp db prefix --allow-root`);
+        const prefix = prefixRes.stdout.trim() || 'wp_';
+
+        // 1. Featured images (_thumbnail_id) — a raw UPDATE with no --dry-run
+        //    switch, so in dry-run mode we only COUNT the affected rows.
+        if (isDryRun) {
+          const countRes = await sshExec(
+            ssh,
+            `${cd} && wp db query "SELECT COUNT(*) FROM ${prefix}postmeta WHERE meta_key='_thumbnail_id' AND meta_value='${id}'" --skip-column-names --allow-root`,
+          );
+          info(`  Would update ${countRes.stdout.trim() || 0} featured-image reference(s).`);
+        } else {
+          await run(
+            'featured-image update',
+            `wp db query "UPDATE ${prefix}postmeta SET meta_value='${newId}' WHERE meta_key='_thumbnail_id' AND meta_value='${id}'"`,
+          );
           info('  ✓ Updated _thumbnail_id references.');
         }
 
-        // 2. Search-replace the old URL with the new URL in post content.
+        // 2. URL replacement across ALL tables (page builders store URLs in
+        //    postmeta/options too). --precise keeps serialized data valid.
         if (oldItem.url && newItem.url) {
-          const replaceResult = await sshExec(
-            site.ssh,
-            `cd ${site.ssh.wpPath} && wp search-replace "${oldItem.url}" "${newItem.url}" wp_posts --precise ${dryRunFlag} --allow-root`,
+          const out = await run(
+            'URL replacement',
+            `wp search-replace ${shellQuote(oldItem.url)} ${shellQuote(newItem.url)} --precise ${dryRunFlag}`,
           );
-          info(`  ✓ URL replacement: ${replaceResult.stdout.trim()}`);
+          info(`  ✓ URL replacement: ${out}`);
         }
 
-        // 3. Replace Gutenberg block IDs.
-        const blockOld = `"id":${id}`;
-        const blockNew = `"id":${newId}`;
-        const blockResult = await sshExec(
-          site.ssh,
-          `cd ${site.ssh.wpPath} && wp search-replace '${blockOld}' '${blockNew}' wp_posts --precise ${dryRunFlag} --allow-root`,
+        // 3. Gutenberg block IDs — regex-anchored so rewriting id 12 can't
+        //    corrupt 123. Restricted to post_content (regex isn't serialize-safe,
+        //    and block markup only lives there).
+        const blockPattern = `"id":${id}(?![0-9])`;
+        const blockReplace = `"id":${newId}`;
+        const out = await run(
+          'block ID replacement',
+          `wp search-replace ${shellQuote(blockPattern)} ${shellQuote(blockReplace)} ${prefix}posts --include-columns=post_content --regex ${dryRunFlag}`,
         );
-        info(`  ✓ Block ID replacement: ${blockResult.stdout.trim()}`);
+        info(`  ✓ Block ID replacement: ${out}`);
 
         if (isDryRun) {
           info('\n  Dry-run complete. Pass --apply to execute the rewrites.');

--- a/src/cli/commands/remove-bg.ts
+++ b/src/cli/commands/remove-bg.ts
@@ -200,7 +200,18 @@ export function registerRemoveBgCommand(program: Command): void {
               const replaceAdapter = resolver.tryResolve('replace-in-place');
               if (replaceAdapter) {
                 try {
-                  await replaceAdapter.replaceInPlace(id, resultBytes);
+                  const formatChanged = item.mimeType !== 'image/png';
+                  await replaceAdapter.replaceInPlace(
+                    id,
+                    resultBytes,
+                    formatChanged
+                      ? {
+                          newMimeType: 'image/png',
+                          newExtension: '.png',
+                          regenerateThumbnails: true,
+                        }
+                      : { regenerateThumbnails: true },
+                  );
                   resultWpId = id;
                 } catch (err) {
                   if (!(err instanceof CapabilityUnavailableError) || parentOpts.strict) {
@@ -400,7 +411,21 @@ export function registerRemoveBgCommand(program: Command): void {
             const replaceAdapter = resolver.tryResolve('replace-in-place');
             if (replaceAdapter) {
               try {
-                await replaceAdapter.replaceInPlace(id, resultBytes);
+                // Output is always PNG (alpha channel). When the source wasn't
+                // PNG, change the file extension + MIME and regenerate thumbnails
+                // so WP serves the right type and thumbnails show the cutout.
+                const formatChanged = item.mimeType !== 'image/png';
+                await replaceAdapter.replaceInPlace(
+                  id,
+                  resultBytes,
+                  formatChanged
+                    ? {
+                        newMimeType: 'image/png',
+                        newExtension: '.png',
+                        regenerateThumbnails: true,
+                      }
+                    : { regenerateThumbnails: true },
+                );
                 resultWpId = id;
               } catch (err) {
                 if (err instanceof CapabilityUnavailableError && !parentOpts.strict) {
@@ -475,21 +500,39 @@ export function registerRemoveBgCommand(program: Command): void {
           error(`    ✗ #${id}: ${message}`);
           failures++;
 
-          db.recordProcessing({
-            siteName: site.name,
-            wpId: id,
-            operation: 'remove-bg',
-            paramsJson: JSON.stringify({ model: modelName }),
-            sourceHash: null,
-            resultHash: null,
-            bytesBefore: null,
-            bytesAfter: null,
-            resultWpId: null,
-            ranAt: Date.now(),
-            durationMs: Date.now() - startTime,
-            status: 'failure',
-            errorMessage: message,
-          });
+          // Recording a failure must never abort the batch. If getMedia() failed
+          // above, no attachments row exists yet — ensure one (FK), then record,
+          // and swallow any error from the recording itself.
+          try {
+            db.upsertAttachment({
+              siteName: site.name,
+              wpId: id,
+              sourceUrl: '',
+              sourceHash: null,
+              sizeBytes: null,
+              width: null,
+              height: null,
+              mimeType: null,
+              lastSeenAt: Date.now(),
+            });
+            db.recordProcessing({
+              siteName: site.name,
+              wpId: id,
+              operation: 'remove-bg',
+              paramsJson: JSON.stringify({ model: modelName }),
+              sourceHash: null,
+              resultHash: null,
+              bytesBefore: null,
+              bytesAfter: null,
+              resultWpId: null,
+              ranAt: Date.now(),
+              durationMs: Date.now() - startTime,
+              status: 'failure',
+              errorMessage: message,
+            });
+          } catch {
+            // Best-effort — never let failure bookkeeping kill the remaining items.
+          }
         }
       }
 

--- a/src/cli/commands/sites.ts
+++ b/src/cli/commands/sites.ts
@@ -12,7 +12,7 @@ import { rmSync } from 'node:fs';
 import type { Command } from 'commander';
 import { ExitCode } from '../../types.ts';
 import { invokeCli } from '../mcp/invoke.ts';
-import { getSiteDbPath, loadConfig, saveConfig } from '../utils/config.ts';
+import { getSiteDbPath, isValidSiteName, loadConfig, saveConfig } from '../utils/config.ts';
 import { error, info, printJson, warn } from '../utils/output.ts';
 
 /**
@@ -139,6 +139,13 @@ export function registerSitesCommand(program: Command): void {
       normalizedUrl = normalizedUrl.replace(/\/+$/, '');
 
       const siteName = options.name ?? new URL(normalizedUrl).hostname;
+
+      if (!isValidSiteName(siteName)) {
+        error(
+          `Invalid site name '${siteName}'. Use only letters, numbers, '.', '_' and '-' (pass --name to override the hostname-derived default).`,
+        );
+        process.exit(2);
+      }
 
       if (!options.username || !options.appPassword) {
         error(

--- a/src/cli/utils/config.ts
+++ b/src/cli/utils/config.ts
@@ -6,10 +6,25 @@
  * deserve filesystem-level protection.
  */
 
-import { chmodSync, mkdirSync } from 'node:fs';
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import type { Config, SiteConfig } from '../../types.ts';
+import { warn } from './output.ts';
+
+/**
+ * Site names become filesystem path components (`<name>.db`, snapshot blob
+ * dirs), so they must not contain path separators or traversal sequences.
+ */
+export function isValidSiteName(name: string): boolean {
+  return /^[A-Za-z0-9._-]+$/.test(name) && name !== '.' && name !== '..';
+}
+
+export function assertValidSiteName(name: string): void {
+  if (!isValidSiteName(name)) {
+    throw new Error(`Invalid site name '${name}'. Use only letters, numbers, '.', '_' and '-'.`);
+  }
+}
 
 /**
  * Resolve the localpress config directory, respecting XDG on Linux/macOS
@@ -84,16 +99,22 @@ export async function saveConfig(config: Config): Promise<void> {
   mkdirSync(dirname(configPath), { recursive: true });
   mkdirSync(getSitesDir(), { recursive: true });
 
-  // Write JSON with 2-space indent.
-  await Bun.write(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  // Write JSON with 2-space indent, creating the file 0600 from the outset so
+  // Application Passwords are never briefly world-readable between write and
+  // chmod. `mode` only applies on creation, so re-chmod existing files below.
+  const data = `${JSON.stringify(config, null, 2)}\n`;
+  if (process.platform === 'win32') {
+    writeFileSync(configPath, data);
+    return;
+  }
 
-  // Restrict permissions on POSIX (Application Passwords are sensitive).
-  if (process.platform !== 'win32') {
-    try {
-      chmodSync(configPath, 0o600);
-    } catch {
-      // Best-effort; some filesystems don't support chmod.
-    }
+  writeFileSync(configPath, data, { mode: 0o600 });
+  try {
+    // Enforce 0600 even when the file already existed (mode is ignored then).
+    chmodSync(configPath, 0o600);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    warn(`Could not set 0600 permissions on ${configPath}: ${message}`);
   }
 }
 

--- a/src/cli/utils/run-mode.ts
+++ b/src/cli/utils/run-mode.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared dry-run / apply resolution for mutating commands.
+ *
+ * The global `--dry-run` and `--apply` flags live on the root program, so every
+ * command reads them via `program.opts()`. Bulk commands (optimize --all, …)
+ * default to dry-run and require `--apply`; explicit destructive commands
+ * (delete, posts delete/update, metadata) execute by default but must honor a
+ * `--dry-run` the user passed to preview.
+ *
+ * Centralizing this here keeps the safety semantics identical across commands —
+ * a `--dry-run` must NEVER reach a mutation.
+ */
+
+/** The subset of global options that affect run mode. */
+export interface RunModeOpts {
+  dryRun?: boolean;
+  apply?: boolean;
+}
+
+/**
+ * Resolve whether a command should run in dry-run (preview) mode.
+ *
+ * - `--apply` always forces execution (opts out of any dry-run default).
+ * - Otherwise an explicit `--dry-run` forces preview.
+ * - Otherwise fall back to the command's default posture.
+ *
+ * @param parentOpts result of `program.opts()`
+ * @param defaultDryRun the command's default when neither flag is passed
+ *   (true for bulk `--all` ops, false for explicit-ID destructive ops)
+ */
+export function resolveDryRun(parentOpts: RunModeOpts, defaultDryRun: boolean): boolean {
+  if (parentOpts.apply) return false;
+  if (parentOpts.dryRun) return true;
+  return defaultDryRun;
+}

--- a/src/engine/history/store.ts
+++ b/src/engine/history/store.ts
@@ -21,7 +21,7 @@
 
 import type { Database } from 'bun:sqlite';
 import { randomUUID } from 'node:crypto';
-import { mkdirSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import type {
   HistoryStats,
@@ -177,8 +177,12 @@ export class SnapshotStore {
       const ext = pickExtension(opts.beforeMeta);
       blobPath = join(this.blobRoot, opts.siteName, opts.sessionId, `${opts.attachmentId}${ext}`);
       mkdirSync(dirname(blobPath), { recursive: true });
-      // Bun.write returns a number of bytes written; cast to satisfy the void return.
-      void Bun.write(blobPath, opts.sourceBytes);
+      // Write the blob synchronously BEFORE inserting the DB row. A detached
+      // async write can leave a committed snapshot row pointing at a missing or
+      // truncated file if the process exits first — and its rejection would be
+      // an uncatchable unhandled rejection. If this throws, no row is created
+      // and the best-effort caller (captureSnapshot) swallows it.
+      writeFileSync(blobPath, opts.sourceBytes);
       blobSize = opts.sourceBytes.length;
     }
 

--- a/src/engine/image/optimize.ts
+++ b/src/engine/image/optimize.ts
@@ -24,6 +24,38 @@ import type {
   OptimizeResult,
 } from './types.ts';
 
+/** Formats the engine can actually encode. Anything else (e.g. svg) must not
+ * be silently rasterized — sharp would emit PNG bytes under the wrong label. */
+const ENCODABLE_FORMATS: readonly ImageFormat[] = ['jpeg', 'png', 'webp', 'avif', 'gif'];
+
+/** Formats that can hold multi-frame animation. */
+const ANIMATION_CAPABLE_FORMATS: readonly ImageFormat[] = ['gif', 'webp'];
+
+/**
+ * Thrown when the requested output format is not one the engine can encode
+ * (e.g. SVG). Callers should skip the item rather than corrupt it.
+ */
+export class UnsupportedFormatError extends Error {
+  constructor(public readonly format: string) {
+    super(`Unsupported image format: ${format}`);
+    this.name = 'UnsupportedFormatError';
+  }
+}
+
+/**
+ * Thrown when an animated source would be flattened by converting to a format
+ * that cannot preserve animation (jpeg/png/avif). Callers should skip and warn.
+ */
+export class AnimatedImageError extends Error {
+  constructor(
+    public readonly sourceFormat: string,
+    public readonly targetFormat: string,
+  ) {
+    super(`Cannot convert animated ${sourceFormat} to ${targetFormat} without losing animation`);
+    this.name = 'AnimatedImageError';
+  }
+}
+
 /**
  * Optimize an image buffer according to the given options.
  *
@@ -42,6 +74,7 @@ export async function optimizeImage(
 
   // Probe the source image for metadata.
   const metadata = await sharp(sourceBytes).metadata();
+  const isAnimated = (metadata.pages ?? 1) > 1;
   const before: ImageInfo = {
     format: mimeToFormat(sourceMimeType) ?? (metadata.format as ImageFormat) ?? 'jpeg',
     width: metadata.width ?? 0,
@@ -51,6 +84,18 @@ export async function optimizeImage(
   };
 
   const targetFormat = opts.toFormat ?? before.format;
+
+  // Guard: never silently rasterize an unencodable format (e.g. svg → png bytes).
+  if (!ENCODABLE_FORMATS.includes(targetFormat)) {
+    throw new UnsupportedFormatError(targetFormat);
+  }
+
+  // Guard: don't flatten animation into a single frame. Preserve it where the
+  // target can hold it; otherwise refuse so the caller can skip and warn.
+  if (isAnimated && !ANIMATION_CAPABLE_FORMATS.includes(targetFormat)) {
+    throw new AnimatedImageError(before.format, targetFormat);
+  }
+
   const mode: CompressionMode = opts.mode ?? defaultMode(targetFormat);
   const supportsQualityTuning =
     targetFormat === 'jpeg' || targetFormat === 'webp' || targetFormat === 'avif';
@@ -59,7 +104,11 @@ export async function optimizeImage(
   let appliedSteps: string[];
   let finalQuality: number | undefined;
 
-  if (opts.targetSizeBytes && supportsQualityTuning) {
+  // Lossless formats don't respond to the quality knob, so a target-size
+  // binary search would just burn encodes and return an oversized result.
+  const canSearchTargetSize = supportsQualityTuning && mode !== 'lossless';
+
+  if (opts.targetSizeBytes && canSearchTargetSize) {
     // Binary-search quality to hit the target file size.
     const result = await binarySearchQuality(
       sharp,
@@ -67,6 +116,7 @@ export async function optimizeImage(
       opts,
       targetFormat,
       mode,
+      isAnimated,
       opts.targetSizeBytes,
     );
     outputBuffer = result.bytes;
@@ -75,7 +125,15 @@ export async function optimizeImage(
   } else {
     // Normal single-pass encoding.
     const quality = opts.quality ?? defaultQuality(targetFormat, mode);
-    const result = await encodeImage(sharp, sourceBytes, opts, targetFormat, mode, quality);
+    const result = await encodeImage(
+      sharp,
+      sourceBytes,
+      opts,
+      targetFormat,
+      mode,
+      isAnimated,
+      quality,
+    );
     outputBuffer = result.bytes;
     appliedSteps = result.steps;
     finalQuality = supportsQualityTuning ? quality : undefined;
@@ -118,12 +176,20 @@ async function encodeImage(
   opts: OptimizeOptions,
   targetFormat: ImageFormat,
   mode: CompressionMode,
+  animated: boolean,
   quality: number,
 ): Promise<{ bytes: Buffer; steps: string[] }> {
-  let pipeline = sharp(sourceBytes);
+  // Decode every frame when the source is animated so multi-frame output
+  // (gif/webp) preserves the animation instead of keeping only frame 1.
+  let pipeline = animated ? sharp(sourceBytes, { animated: true }) : sharp(sourceBytes);
   const steps: string[] = [];
 
-  // Resize if requested.
+  // Always auto-rotate based on EXIF orientation so pixels are stored upright.
+  // (Doing this unconditionally fixes sideways photos when metadata is kept.)
+  pipeline = pipeline.rotate();
+  steps.push('auto-rotate');
+
+  // Resize if requested (after rotate, so max-width applies to the upright image).
   if (opts.maxWidth || opts.maxHeight) {
     pipeline = pipeline.resize({
       width: opts.maxWidth,
@@ -134,10 +200,12 @@ async function encodeImage(
     steps.push(`resize(${opts.maxWidth ?? 'auto'}×${opts.maxHeight ?? 'auto'})`);
   }
 
-  // Auto-rotate based on EXIF orientation, then strip metadata.
-  if (opts.stripMetadata !== false) {
-    pipeline = pipeline.rotate();
-    steps.push('auto-rotate');
+  // Sharp strips metadata by default. When the caller explicitly asks to keep
+  // it, preserve it (orientation is already baked into pixels by .rotate()).
+  if (opts.stripMetadata === false) {
+    pipeline = pipeline.keepMetadata();
+    steps.push('keep-metadata');
+  } else {
     steps.push('strip-metadata');
   }
 
@@ -148,7 +216,19 @@ async function encodeImage(
   if (useJsquash) {
     // Use sharp for transforms then extract raw pixels for jSquash encoding.
     const rawBuffer = await pipeline.ensureAlpha().raw().toBuffer({ resolveWithObject: true });
-    const pixels = new Uint8ClampedArray(rawBuffer.data.buffer);
+    // The raw Buffer is frequently a view into a larger pooled ArrayBuffer, so
+    // honor byteOffset/byteLength — viewing from offset 0 reads unrelated heap.
+    const pixels = new Uint8ClampedArray(
+      rawBuffer.data.buffer,
+      rawBuffer.data.byteOffset,
+      rawBuffer.data.byteLength,
+    );
+    const expected = rawBuffer.info.width * rawBuffer.info.height * 4;
+    if (pixels.length !== expected) {
+      throw new Error(
+        `jsquash: raw pixel length ${pixels.length} != expected ${expected} (w=${rawBuffer.info.width} h=${rawBuffer.info.height})`,
+      );
+    }
 
     const jsResult = await jsquashEncode(
       pixels,
@@ -163,8 +243,13 @@ async function encodeImage(
     // Apply format-specific encoding via sharp.
     switch (targetFormat) {
       case 'jpeg':
-        bytes = await pipeline.jpeg({ quality, mozjpeg: true }).toBuffer();
-        steps.push(`jpeg(q=${quality}, mozjpeg)`);
+        // JPEG has no alpha; flatten transparency onto white so previously
+        // transparent regions don't render as solid black.
+        bytes = await pipeline
+          .flatten({ background: '#ffffff' })
+          .jpeg({ quality, mozjpeg: true })
+          .toBuffer();
+        steps.push(`jpeg(q=${quality}, mozjpeg, flatten)`);
         break;
       case 'png':
         bytes = await pipeline.png({ compressionLevel: 9, effort: 10 }).toBuffer();
@@ -184,11 +269,7 @@ async function encodeImage(
         break;
       case 'gif':
         bytes = await pipeline.gif().toBuffer();
-        steps.push('gif(passthrough)');
-        break;
-      default:
-        bytes = await pipeline.toBuffer();
-        steps.push(`passthrough(${targetFormat})`);
+        steps.push(animated ? 'gif(animated)' : 'gif');
         break;
     }
   }
@@ -214,6 +295,7 @@ async function binarySearchQuality(
   opts: OptimizeOptions,
   targetFormat: ImageFormat,
   mode: CompressionMode,
+  animated: boolean,
   targetSizeBytes: number,
   maxIterations = 8,
   tolerance = 0.05,
@@ -224,7 +306,15 @@ async function binarySearchQuality(
 
   for (let i = 0; i < maxIterations && lo <= hi; i++) {
     const mid = Math.floor((lo + hi) / 2);
-    const candidate = await encodeImage(sharp, sourceBytes, opts, targetFormat, mode, mid);
+    const candidate = await encodeImage(
+      sharp,
+      sourceBytes,
+      opts,
+      targetFormat,
+      mode,
+      animated,
+      mid,
+    );
 
     if (candidate.bytes.length <= targetSizeBytes) {
       best = { bytes: candidate.bytes, quality: mid, steps: candidate.steps };
@@ -239,7 +329,7 @@ async function binarySearchQuality(
 
   // If no quality satisfied the target, return quality=1 (smallest achievable).
   if (!best) {
-    const candidate = await encodeImage(sharp, sourceBytes, opts, targetFormat, mode, 1);
+    const candidate = await encodeImage(sharp, sourceBytes, opts, targetFormat, mode, animated, 1);
     best = { bytes: candidate.bytes, quality: 1, steps: candidate.steps };
   }
 

--- a/src/engine/state/db.ts
+++ b/src/engine/state/db.ts
@@ -69,12 +69,15 @@ export class SiteDb {
       }
     }
 
-    // Upsert the schema version.
-    db.run(
-      `INSERT INTO schema_version (version) VALUES (?)
-       ON CONFLICT (version) DO UPDATE SET version = excluded.version`,
-      [SCHEMA_VERSION],
-    );
+    // Stamp the schema version only when it actually changed, so read-only
+    // commands (stats, history) don't take a write lock just by opening the DB.
+    if (stored !== SCHEMA_VERSION) {
+      db.run(
+        `INSERT INTO schema_version (version) VALUES (?)
+         ON CONFLICT (version) DO UPDATE SET version = excluded.version`,
+        [SCHEMA_VERSION],
+      );
+    }
 
     return new SiteDb(db);
   }
@@ -155,15 +158,25 @@ export class SiteDb {
     return rows.map(mapAttachmentRow);
   }
 
-  /** List attachment IDs that have been processed (have processing_history). */
-  listProcessedWpIds(siteName: string): Set<number> {
-    const rows = this.db
-      .query(
-        `SELECT DISTINCT wp_id FROM processing_history
-         WHERE site_name = ? AND status = 'success'`,
-      )
-      .all(siteName) as Array<{ wp_id: number }>;
+  /**
+   * List attachment IDs that have been successfully processed.
+   *
+   * Pass `operations` to restrict to specific operation types — e.g.
+   * `['optimize', 'convert', 'resize']` so that a caption/classify/rename pass
+   * doesn't make an image look "already optimized" to `optimize --unoptimized`.
+   */
+  listProcessedWpIds(siteName: string, operations?: readonly string[]): Set<number> {
+    let sql = `SELECT DISTINCT wp_id FROM processing_history
+               WHERE site_name = ? AND status = 'success'`;
+    const params: Array<string> = [siteName];
 
+    if (operations && operations.length > 0) {
+      const placeholders = operations.map(() => '?').join(', ');
+      sql += ` AND operation IN (${placeholders})`;
+      params.push(...operations);
+    }
+
+    const rows = this.db.query(sql).all(...params) as Array<{ wp_id: number }>;
     return new Set(rows.map((r) => r.wp_id));
   }
 

--- a/src/engine/state/schema.ts
+++ b/src/engine/state/schema.ts
@@ -24,6 +24,9 @@ export const SCHEMA_VERSION = 4;
 export const INITIAL_SCHEMA = `
 PRAGMA journal_mode = WAL;
 PRAGMA foreign_keys = ON;
+-- Wait (up to 5s) for a competing writer instead of throwing SQLITE_BUSY, so a
+-- background \`watch\` and a foreground command can share the same site DB.
+PRAGMA busy_timeout = 5000;
 
 CREATE TABLE IF NOT EXISTS schema_version (
   version INTEGER PRIMARY KEY

--- a/test/unit/history.test.ts
+++ b/test/unit/history.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SnapshotStore } from '../../src/engine/history/store.ts';
@@ -59,6 +59,28 @@ describe('SnapshotStore', () => {
     expect(snaps[0].blobPath).not.toBeNull();
     const onDisk = readFileSync(snaps[0].blobPath as string);
     expect(onDisk.toString()).toBe('hello world content');
+  });
+
+  test('blob is written synchronously before capture() returns (durability)', () => {
+    // Regression for the fire-and-forget bug: the DB row must never point at a
+    // blob that isn't on disk yet. capture() writes synchronously, so the file
+    // exists the instant it returns — no event-loop tick required.
+    const session = store.openSession('testsite', 'optimize', { quality: 80 });
+    const bytes = Buffer.from('durable snapshot bytes');
+    store.capture({
+      siteName: 'testsite',
+      sessionId: session.id,
+      attachmentId: 7,
+      operation: 'optimize',
+      sourceBytes: bytes,
+      beforeMeta: { filename: 'a.jpg', mimeType: 'image/jpeg' },
+    });
+
+    const snap = store.listSnapshots('testsite').find((s) => s.wpId === 7);
+    expect(snap?.blobPath).not.toBeNull();
+    // No await between capture() and this read.
+    expect(existsSync(snap?.blobPath as string)).toBe(true);
+    expect(readFileSync(snap?.blobPath as string).toString()).toBe('durable snapshot bytes');
   });
 
   test('metadata-only capture stores no blob', () => {

--- a/test/unit/image-guards.test.ts
+++ b/test/unit/image-guards.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for the image-engine safety guards added in the trust release:
+ *   - SVG / unencodable formats throw instead of silently rasterizing to PNG.
+ *   - Animated sources are preserved for gif/webp and refused for jpeg/png/avif.
+ *   - PNG transparency is flattened (not turned black) when converting to JPEG.
+ *   - EXIF orientation is baked in even when metadata is kept.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  AnimatedImageError,
+  UnsupportedFormatError,
+  optimizeImage,
+} from '../../src/engine/image/optimize.ts';
+
+async function sharpLib() {
+  return (await import('sharp')).default;
+}
+
+/** Build a tiny 2-frame animated GIF. */
+async function makeAnimatedGif(): Promise<Buffer> {
+  const sharp = await sharpLib();
+  const width = 8;
+  const height = 8;
+  const channels = 4;
+  const frame = (v: number) => {
+    const buf = Buffer.alloc(width * height * channels);
+    for (let i = 0; i < buf.length; i += channels) {
+      buf[i] = v;
+      buf[i + 1] = v;
+      buf[i + 2] = v;
+      buf[i + 3] = 255;
+    }
+    return buf;
+  };
+  const two = Buffer.concat([frame(0), frame(255)]);
+  return sharp(two, {
+    raw: { width, height: height * 2, channels },
+    animated: true,
+    pageHeight: height,
+    // biome-ignore lint/suspicious/noExplicitAny: pageHeight isn't in sharp's raw types
+  } as any)
+    .gif()
+    .toBuffer();
+}
+
+// Some libvips builds ship without GIF/WebP animation (no cgif). The animation
+// guards only matter — and are only testable — where multi-frame is supported,
+// so probe once and skip those cases gracefully elsewhere.
+async function detectAnimationSupport(): Promise<boolean> {
+  try {
+    const sharp = await sharpLib();
+    const gif = await makeAnimatedGif();
+    return ((await sharp(gif).metadata()).pages ?? 1) > 1;
+  } catch {
+    return false;
+  }
+}
+const ANIMATION_SUPPORTED = await detectAnimationSupport();
+
+describe('optimizeImage — format guards', () => {
+  test('SVG source throws UnsupportedFormatError instead of rasterizing', async () => {
+    const svg = Buffer.from(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10" fill="red"/></svg>',
+    );
+    // Force the target format to svg (the real bulk path never gets here because
+    // the command whitelist filters SVG out first — this is defense in depth).
+    await expect(
+      optimizeImage(svg, 'image/svg+xml', { toFormat: 'svg' as never }),
+    ).rejects.toBeInstanceOf(UnsupportedFormatError);
+  });
+});
+
+describe('optimizeImage — animation handling', () => {
+  test.skipIf(!ANIMATION_SUPPORTED)(
+    'animated GIF stays animated through same-format optimize',
+    async () => {
+      const sharp = await sharpLib();
+      const gif = await makeAnimatedGif();
+      expect((await sharp(gif).metadata()).pages).toBeGreaterThan(1);
+
+      const result = await optimizeImage(gif, 'image/gif', {});
+      const outPages = (await sharp(result.bytes).metadata()).pages ?? 1;
+      expect(outPages).toBeGreaterThan(1);
+    },
+  );
+
+  test.skipIf(!ANIMATION_SUPPORTED)(
+    'animated GIF is preserved when converting to WebP',
+    async () => {
+      const sharp = await sharpLib();
+      const gif = await makeAnimatedGif();
+      const result = await optimizeImage(gif, 'image/gif', { toFormat: 'webp' });
+      const outPages = (await sharp(result.bytes).metadata()).pages ?? 1;
+      expect(outPages).toBeGreaterThan(1);
+    },
+  );
+
+  test.skipIf(!ANIMATION_SUPPORTED)(
+    'animated GIF → JPEG throws AnimatedImageError (would lose animation)',
+    async () => {
+      const gif = await makeAnimatedGif();
+      await expect(optimizeImage(gif, 'image/gif', { toFormat: 'jpeg' })).rejects.toBeInstanceOf(
+        AnimatedImageError,
+      );
+    },
+  );
+});
+
+describe('optimizeImage — fidelity', () => {
+  test('transparent PNG → JPEG flattens transparency to white, not black', async () => {
+    const sharp = await sharpLib();
+    // A fully transparent 16x16 image.
+    const transparent = await sharp({
+      create: { width: 16, height: 16, channels: 4, background: { r: 0, g: 0, b: 0, alpha: 0 } },
+    })
+      .png()
+      .toBuffer();
+
+    const result = await optimizeImage(transparent, 'image/png', { toFormat: 'jpeg' });
+    const { data } = await sharp(result.bytes).raw().toBuffer({ resolveWithObject: true });
+    // Center pixel should be white (flattened), not black.
+    expect(data[0]).toBeGreaterThan(240);
+    expect(data[1]).toBeGreaterThan(240);
+    expect(data[2]).toBeGreaterThan(240);
+  });
+
+  test('EXIF orientation is baked in even when metadata is kept', async () => {
+    const sharp = await sharpLib();
+    // 20x10 landscape image tagged orientation 6 (rotate 90° CW on display →
+    // renders as 10x20 portrait). After optimize the pixels must be upright.
+    const tagged = await sharp({
+      create: { width: 20, height: 10, channels: 3, background: { r: 10, g: 20, b: 30 } },
+    })
+      .withMetadata({ orientation: 6 })
+      .jpeg()
+      .toBuffer();
+
+    const result = await optimizeImage(tagged, 'image/jpeg', { stripMetadata: false });
+    const meta = await sharp(result.bytes).metadata();
+    // Pixels are physically rotated to portrait; no residual orientation flag.
+    expect(meta.width).toBe(10);
+    expect(meta.height).toBe(20);
+    expect(meta.orientation ?? 1).toBe(1);
+  });
+});

--- a/test/unit/processed-filter.test.ts
+++ b/test/unit/processed-filter.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit test for listProcessedWpIds(operation) — `optimize --unoptimized` must
+ * only skip images that were actually compressed, not ones a caption/classify
+ * pass touched (#98).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { SiteDb } from '../../src/engine/state/db.ts';
+
+function seed(db: SiteDb, wpId: number, operation: string) {
+  db.upsertAttachment({
+    siteName: 'site',
+    wpId,
+    sourceUrl: `https://example.test/${wpId}.jpg`,
+    sourceHash: null,
+    sizeBytes: null,
+    width: null,
+    height: null,
+    mimeType: 'image/jpeg',
+    lastSeenAt: Date.now(),
+  });
+  db.recordProcessing({
+    siteName: 'site',
+    wpId,
+    operation,
+    paramsJson: '{}',
+    sourceHash: null,
+    resultHash: null,
+    bytesBefore: null,
+    bytesAfter: null,
+    resultWpId: null,
+    ranAt: Date.now(),
+    durationMs: 1,
+    status: 'success',
+    errorMessage: null,
+  });
+}
+
+describe('listProcessedWpIds', () => {
+  test('operation filter excludes caption-only history from "optimized"', () => {
+    const db = SiteDb.init(':memory:');
+    db.ensureSite('site', 'https://example.test');
+
+    seed(db, 1, 'optimize');
+    seed(db, 2, 'caption');
+    seed(db, 3, 'classify');
+    seed(db, 4, 'convert');
+
+    // No filter: every processed id, regardless of operation.
+    const all = db.listProcessedWpIds('site');
+    expect([...all].sort()).toEqual([1, 2, 3, 4]);
+
+    // Compression-only filter: caption/classify must NOT count as optimized.
+    const optimized = db.listProcessedWpIds('site', ['optimize', 'convert', 'resize']);
+    expect([...optimized].sort()).toEqual([1, 4]);
+    expect(optimized.has(2)).toBe(false);
+    expect(optimized.has(3)).toBe(false);
+
+    db.close();
+  });
+});

--- a/test/unit/run-mode.test.ts
+++ b/test/unit/run-mode.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Unit tests for the shared dry-run/apply resolution used by destructive
+ * commands (delete, posts delete/update, metadata, references --update-to).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { resolveDryRun } from '../../src/cli/utils/run-mode.ts';
+
+describe('resolveDryRun', () => {
+  test('explicit-destructive default (false): executes when no flags', () => {
+    expect(resolveDryRun({}, false)).toBe(false);
+  });
+
+  test('explicit --dry-run forces preview for a default-execute command', () => {
+    expect(resolveDryRun({ dryRun: true }, false)).toBe(true);
+  });
+
+  test('--apply always wins over --dry-run', () => {
+    expect(resolveDryRun({ dryRun: true, apply: true }, false)).toBe(false);
+    expect(resolveDryRun({ dryRun: true, apply: true }, true)).toBe(false);
+  });
+
+  test('bulk default (true): dry-run unless --apply', () => {
+    expect(resolveDryRun({}, true)).toBe(true);
+    expect(resolveDryRun({ apply: true }, true)).toBe(false);
+  });
+});

--- a/test/unit/site-name.test.ts
+++ b/test/unit/site-name.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Unit test for site-name validation — names become filesystem path components
+ * (<name>.db, snapshot blob dirs), so traversal/separators must be rejected (#118).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { isValidSiteName } from '../../src/cli/utils/config.ts';
+
+describe('isValidSiteName', () => {
+  test('accepts ordinary names', () => {
+    for (const ok of ['production', 'staging', 'my-site', 'site_1', 'example.com']) {
+      expect(isValidSiteName(ok)).toBe(true);
+    }
+  });
+
+  test('rejects traversal and path separators', () => {
+    for (const bad of ['../evil', '..', '.', 'a/b', 'a\\b', 'foo/../bar', '', 'has space']) {
+      expect(isValidSiteName(bad)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This is the **2.1 "trustworthy by default"** release proposed in #135 — the highest-value cluster from the v2.0.0 audit, shipped together so it can merge and deploy as one release. It adds **no new command surface**; every change makes an existing operation safer or more correct.

The audit's central finding was that localpress does irreversible things to live sites while its safety mechanisms (dry-run, undo, idempotency, reference tracking) had holes. This PR closes those holes.

`bun typecheck`, `bun lint`, and the unit suite (**223 pass / 3 env-skipped / 0 fail**, +25 new assertions) are all green.

## Data safety (critical)

- **`references --update-to` is safe** (#89): the `_thumbnail_id` UPDATE no longer runs under `--dry-run` (reports a count instead); the block-ID rewrite is a boundary-anchored regex scoped to `post_content` so rewriting attachment `12` can't corrupt `123`; URL replacement runs across all tables (serialize-safe) instead of `wp_posts` only; the real table prefix is resolved; partial-failure state is reported.
- **Global `--dry-run` is honored** by `delete`, `posts delete`, `posts update`, and `metadata` (#90) via a shared `resolveDryRun` helper — these previously ignored it and executed for real.
- **Animation is preserved, not flattened** (#93): multi-frame GIF/WebP stay animated for gif/webp targets and are skipped (with a warning) for formats that can't hold animation.
- **SVG/unencodable formats are skipped, not rasterized** (#94): the bulk path filters to a MIME whitelist and the engine throws rather than writing PNG bytes under a `.svg` name.
- **Snapshots are durable** (#92): blobs are written synchronously before the history row is committed, so an interrupted run can't leave `undo` pointing at a missing/truncated file.

## Correctness (high)

- **`remove-bg` replace-in-place** sets the PNG mime/extension + regenerates thumbnails (#95); failure recording is FK-safe so a bad ID can't abort the batch (#96).
- **`optimize --unoptimized`** is filtered to compression operations, so caption/classify/rename passes don't make images look "already optimized" (#98).
- **jsquash** honors the raw buffer's `byteOffset`/`byteLength`, fixing out-of-bounds pixel reads (#100).
- **REST reference scan finds Gutenberg embeds** via `context=edit` + raw content (with a `wp-image-<id>` rendered fallback); `getMedia` returns raw fields so `tag`/`vision` don't flatten captions (#101).
- **`delete`** surfaces actionable guidance when a site lacks `MEDIA_TRASH` instead of an opaque 501 (#102).

## Robustness (medium)

- SQLite `busy_timeout` + conditional version stamp so `watch` + a foreground command sharing a DB don't crash with "database is locked" (#114).
- Config written `0600` atomically (Application Passwords never briefly world-readable); site-name path-traversal validation; failed chmod warns instead of swallowing (#118).
- Zip Slip guard on `import` (#107).
- PNG→JPEG flatten (no more black boxes), always auto-rotate (EXIF orientation kept upright), accurate `--target-size` warning, and `posts update` can clear a field.

## Tests

New unit coverage: image-engine guards (SVG/animation/flatten/orientation), the `resolveDryRun` helper, the `listProcessedWpIds` operation filter, site-name validation, and synchronous snapshot durability. Animation runtime tests self-skip on libvips builds without cgif (this CI runner) and run where animation is supported.

## Deliberately deferred

The behaviorally-riskiest audit items — the full idempotency redesign (#97), undo format-change round-trip restore (#91), and the preview-server auth/apply-race work (#105/#106) — need live-WordPress validation and are left for a focused follow-up rather than risking this release.

Closes #89, #90, #92, #93, #94, #95, #96, #98, #100, #101, #102, #107, #114, #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KLqDSup6HVMJk8vK1TXjS

---
_Generated by [Claude Code](https://claude.ai/code/session_018KLqDSup6HVMJk8vK1TXjS)_