### PR TITLE
Trust + correctness (v2.2.0): undo/idempotency/preview + WP-CLI hardening, audit, sites run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,30 @@ optimize idempotency, and preview-server hardening.
   same Host check.
 - Browser launch is now best-effort and never throws in headless environments.
 
+### Fixed — correctness & security (medium)
+- **WP-CLI command construction is fully shell-hardened** (#112). All interpolated
+  values — titles, alt text, captions, descriptions, paths, and the
+  `_wp_attachment_metadata` JSON — are single-quote escaped via a shared
+  `shellQuote` helper, so content containing quotes/`$`/backticks/`;` can't break
+  the command or inject execution. Fixes the broken `\'`-in-single-quotes JSON
+  escaping that silently corrupted metadata on apostrophes, groups the
+  `pruneOrphans` `find` predicate so directories aren't reported as orphan files,
+  and makes temp filenames collision-proof under concurrency.
+- **`audit` correctness** (#111): no longer crashes on a library whose size is an
+  exact multiple of 100 (treats the resulting 400 as "no more pages");
+  `--unattached` is now implemented (attachments with parent post 0) instead of
+  silently returning nothing; `--broken-refs` is re-documented and rewritten as
+  an honest missing-source-file probe (404/410) that retries once and never
+  reports transient network errors as broken; and duplicate detection is excluded
+  from a bare `audit` (it downloaded every image's full bytes).
+- **`sites run` forwards run mode and bounds child time** (#104): `--apply`,
+  `--dry-run`, `--strict`, and `--yes` set on the parent are passed through to
+  each per-site child (previously a cross-site `optimize --apply` silently ran as
+  a dry-run while reporting success); the per-child timeout defaults to 1 hour
+  with a `--timeout` override (`0` disables), and a SIGTERM is escalated to
+  SIGKILL so a stuck child can't hang the run. The command tokenizer now
+  preserves an explicitly empty quoted argument (`--alt-text ""`).
+
 ## [2.1.0] - 2026-07-05
 
 Trust & correctness release — hardens the safety primitives (dry-run, undo,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-07-05
+
+Completes the trust story started in 2.1.0 — the three deferred safety items
+that needed careful, tested implementations: undo after a format change, correct
+optimize idempotency, and preview-server hardening.
+
+### Fixed — undo correctness (critical)
+- **`undo` after a format-changing optimize restores the file correctly** (#91).
+  It now detects that the forward op changed the format (e.g. png→webp), fetches
+  the current attachment, and passes `newExtension` + thumbnail regeneration so
+  the file is renamed back, the MIME is restored, the wrong-format file is
+  removed, and thumbnails are rebuilt from the original bytes — instead of
+  writing the original bytes under the new extension. Warns to re-check
+  references when the forward op changed the URL.
+
+### Fixed — idempotency (high)
+- **`optimize` is safe to re-run** (#97). The skip now compares the current file
+  against the previous run's OUTPUT hash (`resultHash`) with matching params,
+  instead of the previous source hash. Re-running with the same settings is a
+  true no-op (no re-compression, no generational quality loss, no double-counted
+  stats), a restored/undone file re-optimizes correctly, and changing any param
+  re-runs. Adds **`optimize --force`** to bypass the skip.
+
+### Fixed — preview server (high / security)
+- **Preview "Apply" reports success** (#105). A `resolveOnce` guard plus
+  resolving before shutdown fixes the WebSocket-close race that made every
+  successful apply report "Preview cancelled". Reloading the preview tab (F5) no
+  longer kills the session (a short reconnect grace window was added).
+- **Preview endpoints are authenticated** (#106). A per-session token (delivered
+  via the URL fragment, never sent to the server or logged) is required on every
+  mutating endpoint, and a `Host`-header check rejects DNS-rebinding. No other
+  local process or web page can drive `/api/apply` to overwrite an attachment.
+  Injected client-side with zero changes to the UI code. quick-view gets the
+  same Host check.
+- Browser launch is now best-effort and never throws in headless environments.
+
 ## [2.1.0] - 2026-07-05
 
 Trust & correctness release — hardens the safety primitives (dry-run, undo,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localpress",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Local-compute WordPress media optimization. Your laptop, your library.",
   "license": "MIT",
   "author": "Griffen Fargo",

--- a/src/adapters/rest.ts
+++ b/src/adapters/rest.ts
@@ -368,6 +368,8 @@ interface WpMediaResponse {
   description?: { rendered: string; raw?: string };
   date: string;
   slug: string;
+  /** Parent post the attachment is attached to; 0 when unattached. */
+  post?: number | null;
 }
 
 interface WpPostResponse {
@@ -445,6 +447,7 @@ function mapWpMediaToItem(raw: WpMediaResponse): MediaItem {
     description: raw.description?.raw ?? stripHtml(raw.description?.rendered),
     uploadedAt: raw.date,
     sizes: Object.keys(sizes).length > 0 ? sizes : undefined,
+    parentPost: raw.post ?? undefined,
   };
 }
 

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -47,6 +47,11 @@ export interface MediaItem {
   uploadedAt: string;
   /** WordPress's auto-generated thumbnail/medium/large variants. */
   sizes?: Record<string, MediaSize>;
+  /**
+   * Parent post ID this attachment is "attached" to (WP `post` field). 0 means
+   * unattached. Undefined if the backend didn't provide it.
+   */
+  parentPost?: number;
 }
 
 export interface MediaSize {

--- a/src/adapters/wp-cli.ts
+++ b/src/adapters/wp-cli.ts
@@ -6,10 +6,11 @@
  * thumbnail regeneration, orphan pruning, full content scans.
  */
 
+import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { SiteConfig, SshConfig } from '../types.ts';
-import { scpUpload, sshExec } from './ssh.ts';
+import { scpUpload, shellQuote, sshExec } from './ssh.ts';
 import type {
   Capability,
   ListFilters,
@@ -53,7 +54,7 @@ export class WpCliAdapter implements WpBackend {
   // -- Internal WP-CLI execution ----------------------------------------------
 
   private async wp(command: string): Promise<string> {
-    const fullCommand = `cd ${this.wpPath} && wp ${command} --allow-root`;
+    const fullCommand = `cd ${shellQuote(this.wpPath)} && wp ${command} --allow-root`;
     const result = await sshExec(this.ssh, fullCommand);
 
     if (result.exitCode !== 0) {
@@ -186,11 +187,14 @@ export class WpCliAdapter implements WpBackend {
   // Mutation ------------------------------------------------------------------
 
   async upload(file: Buffer, metadata: UploadMetadata): Promise<MediaItem> {
-    // Write the file to a local temp path, then SCP to remote.
-    const localTmp = join(tmpdir(), `localpress-upload-${Date.now()}-${metadata.filename}`);
+    // Write the file to a local temp path, then SCP to remote. A UUID keeps the
+    // temp name unique under concurrency while preserving the original filename
+    // (WP derives the attachment name from the imported file's basename).
+    const unique = `${Date.now()}-${randomUUID()}`;
+    const localTmp = join(tmpdir(), `localpress-upload-${unique}-${metadata.filename}`);
     await Bun.write(localTmp, file);
 
-    const remoteTmp = `/tmp/localpress-upload-${Date.now()}-${metadata.filename}`;
+    const remoteTmp = `/tmp/localpress-upload-${unique}-${metadata.filename}`;
     const scpResult = await scpUpload(this.ssh, localTmp, remoteTmp);
     if (scpResult.exitCode !== 0) {
       throw new Error(
@@ -198,12 +202,14 @@ export class WpCliAdapter implements WpBackend {
       );
     }
 
-    // Import via WP-CLI.
-    const args = [`media import "${remoteTmp}"`, '--porcelain'];
-    if (metadata.title) args.push(`--title="${metadata.title}"`);
-    if (metadata.altText) args.push(`--alt="${metadata.altText}"`);
-    if (metadata.caption) args.push(`--caption="${metadata.caption}"`);
-    if (metadata.description) args.push(`--description="${metadata.description}"`);
+    // Import via WP-CLI. Every interpolated value is shell-escaped — titles /
+    // alt text / captions are arbitrary editor- or AI-generated content and
+    // must never be able to break the command or inject shell execution.
+    const args = [`media import ${shellQuote(remoteTmp)}`, '--porcelain'];
+    if (metadata.title) args.push(`--title=${shellQuote(metadata.title)}`);
+    if (metadata.altText) args.push(`--alt=${shellQuote(metadata.altText)}`);
+    if (metadata.caption) args.push(`--caption=${shellQuote(metadata.caption)}`);
+    if (metadata.description) args.push(`--description=${shellQuote(metadata.description)}`);
     if (metadata.postId) args.push(`--post_id=${metadata.postId}`);
 
     const output = await this.wp(args.join(' '));
@@ -214,7 +220,7 @@ export class WpCliAdapter implements WpBackend {
     }
 
     // Clean up remote temp file.
-    await sshExec(this.ssh, `rm -f "${remoteTmp}"`).catch(() => {});
+    await sshExec(this.ssh, `rm -f ${shellQuote(remoteTmp)}`).catch(() => {});
 
     // Clean up local temp file.
     try {
@@ -247,10 +253,12 @@ export class WpCliAdapter implements WpBackend {
     }
 
     // Write to local temp, SCP to remote, place at the (possibly new) path.
-    const localTmp = join(tmpdir(), `localpress-replace-${Date.now()}`);
+    // A UUID avoids collisions between concurrent replace operations.
+    const unique = `${Date.now()}-${randomUUID()}`;
+    const localTmp = join(tmpdir(), `localpress-replace-${unique}`);
     await Bun.write(localTmp, file);
 
-    const remoteTmp = `/tmp/localpress-replace-${Date.now()}`;
+    const remoteTmp = `/tmp/localpress-replace-${unique}`;
     const scpResult = await scpUpload(this.ssh, localTmp, remoteTmp);
     if (scpResult.exitCode !== 0) {
       throw new Error(
@@ -260,7 +268,7 @@ export class WpCliAdapter implements WpBackend {
 
     // Ensure the target directory exists, then move the file into place.
     const targetDir = remotePath.substring(0, remotePath.lastIndexOf('/'));
-    const mkdirResult = await sshExec(this.ssh, `mkdir -p "${targetDir}"`);
+    const mkdirResult = await sshExec(this.ssh, `mkdir -p ${shellQuote(targetDir)}`);
     if (mkdirResult.exitCode !== 0) {
       throw new Error(
         `Failed to create target directory "${targetDir}": ${mkdirResult.stderr || 'unknown error'}`,
@@ -269,7 +277,7 @@ export class WpCliAdapter implements WpBackend {
 
     const mvResult = await sshExec(
       this.ssh,
-      `mv "${remoteTmp}" "${remotePath}" && chmod 644 "${remotePath}"`,
+      `mv ${shellQuote(remoteTmp)} ${shellQuote(remotePath)} && chmod 644 ${shellQuote(remotePath)}`,
     );
     if (mvResult.exitCode !== 0) {
       throw new Error(
@@ -281,17 +289,14 @@ export class WpCliAdapter implements WpBackend {
     if (options?.newExtension && newFilePath !== currentFile.trim()) {
       const oldRemotePath = `${uploadsDir}/${currentFile.trim()}`;
       // Delete the old file (it's now at a different path).
-      await sshExec(this.ssh, `rm -f "${oldRemotePath}"`).catch(() => {});
+      await sshExec(this.ssh, `rm -f ${shellQuote(oldRemotePath)}`).catch(() => {});
 
       // Update _wp_attached_file meta to the new path.
-      await this.wp(`post meta update ${id} _wp_attached_file "${newFilePath}"`);
+      await this.wp(`post meta update ${id} _wp_attached_file ${shellQuote(newFilePath)}`);
 
-      // Update the post MIME type via wp post update (handles quoting correctly).
+      // Update the post MIME type.
       if (options.newMimeType) {
-        await sshExec(
-          this.ssh,
-          `cd ${this.wpPath} && wp post update ${id} --post_mime_type="${options.newMimeType}" --allow-root`,
-        );
+        await this.wp(`post update ${id} --post_mime_type=${shellQuote(options.newMimeType)}`);
       }
 
       // Update attachment metadata: file field, filesize, and clear stale sizes.
@@ -308,7 +313,9 @@ export class WpCliAdapter implements WpBackend {
               .map((s) => (s as { file?: string })?.file)
               .filter(Boolean) as string[];
             for (const thumbFile of oldThumbFiles) {
-              await sshExec(this.ssh, `rm -f "${dirPath}/${thumbFile}"`).catch(() => {});
+              await sshExec(this.ssh, `rm -f ${shellQuote(`${dirPath}/${thumbFile}`)}`).catch(
+                () => {},
+              );
             }
           }
 
@@ -317,9 +324,12 @@ export class WpCliAdapter implements WpBackend {
           // Clear the sizes array — old format thumbnails are now invalid.
           // WordPress will repopulate this on regenerate.
           meta.sizes = {};
-          const updatedMeta = JSON.stringify(meta).replace(/'/g, "\\'");
+          // Properly single-quote the JSON for the shell. The previous
+          // `.replace(/'/g, "\\'")` produced `\'`, which POSIX shells do NOT
+          // honor inside single quotes — any apostrophe (e.g. in image_meta
+          // credit/caption) broke the command and silently left stale metadata.
           await this.wp(
-            `post meta update ${id} _wp_attachment_metadata '${updatedMeta}' --format=json`,
+            `post meta update ${id} _wp_attachment_metadata ${shellQuote(JSON.stringify(meta))} --format=json`,
           );
         }
       } catch {
@@ -352,16 +362,18 @@ export class WpCliAdapter implements WpBackend {
 
   async updateMetadata(id: number, metadata: UpdateMetadata): Promise<void> {
     if (metadata.title !== undefined) {
-      await this.wp(`post update ${id} --post_title="${metadata.title}"`);
+      await this.wp(`post update ${id} --post_title=${shellQuote(metadata.title)}`);
     }
     if (metadata.altText !== undefined) {
-      await this.wp(`post meta update ${id} _wp_attachment_image_alt "${metadata.altText}"`);
+      await this.wp(
+        `post meta update ${id} _wp_attachment_image_alt ${shellQuote(metadata.altText)}`,
+      );
     }
     if (metadata.caption !== undefined) {
-      await this.wp(`post update ${id} --post_excerpt="${metadata.caption}"`);
+      await this.wp(`post update ${id} --post_excerpt=${shellQuote(metadata.caption)}`);
     }
     if (metadata.description !== undefined) {
-      await this.wp(`post update ${id} --post_content="${metadata.description}"`);
+      await this.wp(`post update ${id} --post_content=${shellQuote(metadata.description)}`);
     }
   }
 
@@ -380,10 +392,13 @@ export class WpCliAdapter implements WpBackend {
     // Get the uploads directory.
     const uploadsDir = await this.wp(`eval 'echo wp_upload_dir()["basedir"];'`);
 
-    // List all files in uploads.
+    // List all image files in uploads. The extension alternation is grouped so
+    // `-type f` applies to ALL of it — otherwise the precedence is
+    // `(-type f AND *.jpg) OR *.jpeg OR ...`, which matches directories named
+    // e.g. `2023.webp` and reports them as reclaimable orphan "files".
     const filesOutput = await sshExec(
       this.ssh,
-      `find "${uploadsDir.trim()}" -type f -name "*.jpg" -o -name "*.jpeg" -o -name "*.png" -o -name "*.gif" -o -name "*.webp" -o -name "*.avif" | sort`,
+      `find ${shellQuote(uploadsDir.trim())} -type f \\( -name '*.jpg' -o -name '*.jpeg' -o -name '*.png' -o -name '*.gif' -o -name '*.webp' -o -name '*.avif' \\) | sort`,
     );
     const allFiles = filesOutput.stdout.split('\n').filter(Boolean);
 

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -6,12 +6,12 @@
  *   - --large: images larger than --threshold
  *   - --missing-alt: images without alt text
  *   - --display-size: images significantly larger than their largest registered WP size
- *   - --duplicates: perceptual duplicates (pHash via sharp)
- *   - --broken-refs: attachment URLs referenced in content that 404
+ *   - --duplicates: perceptual duplicates (dHash via sharp; opt-in, downloads bytes)
+ *   - --broken-refs: attachments whose source file returns 404/410 (missing on disk)
+ *   - --unattached: attachments with no parent post (WP post parent = 0)
  *
  * WP-CLI checks:
  *   - --orphans: uploads-dir files with no DB record
- *   - --unattached: full reference scan for truly unattached media
  */
 
 import type { Command } from 'commander';
@@ -66,7 +66,10 @@ export function registerAuditCommand(program: Command): void {
       'flag images significantly larger than their largest registered WP thumbnail size',
     )
     .option('--duplicates', 'flag perceptually identical or near-identical images (requires sharp)')
-    .option('--broken-refs', 'flag attachment URLs referenced in post content that return 404')
+    .option(
+      '--broken-refs',
+      'flag attachments whose source file returns HTTP 404/410 (missing on disk)',
+    )
     .option(
       '--quality',
       'flag blurry / low-contrast / poorly-composed images via Ollama vision (slow; ~10s per image)',
@@ -149,7 +152,12 @@ export function registerAuditCommand(program: Command): void {
           if (batch.length < 100) break;
           page++;
         } catch (err) {
-          error(err instanceof Error ? err.message : String(err));
+          // A library whose size is an exact multiple of 100 asks for one page
+          // past the end; WordPress answers 400 rest_post_invalid_page_number.
+          // That just means "no more pages", not a real error.
+          const message = err instanceof Error ? err.message : String(err);
+          if (page > 1 && /invalid_page_number|\b400\b/.test(message)) break;
+          error(message);
           process.exit(4);
           return;
         }
@@ -203,6 +211,18 @@ export function registerAuditCommand(program: Command): void {
           });
         }
 
+        // --unattached: attachment not attached to any parent post (WP post=0).
+        // Not in runAll — inserted-into-content images are legitimately
+        // unattached, so this is an opt-in signal, not a default finding.
+        if (options.unattached && item.parentPost === 0) {
+          findings.push({
+            type: 'unattached',
+            attachmentId: item.id,
+            filename: item.filename,
+            detail: 'Not attached to any post (post parent = 0)',
+          });
+        }
+
         // --display-size: compare source dimensions against largest registered WP size
         if ((runAll || options.displaySize) && item.width && item.height && item.sizes) {
           const largestSize = findLargestRegisteredSize(item.sizes);
@@ -230,16 +250,18 @@ export function registerAuditCommand(program: Command): void {
         }
       }
 
-      // -- Duplicate detection (pHash via sharp) --------------------------------
-      if (options.duplicates || runAll) {
+      // -- Duplicate detection (dHash via sharp) --------------------------------
+      // Excluded from the default runAll: it downloads every image's full bytes
+      // to hash them, which is far too heavy for a bare `audit`. Opt in.
+      if (options.duplicates) {
         const dupeFindings = await detectDuplicates(allItems);
         findings.push(...dupeFindings);
       }
 
-      // -- Broken reference detection ------------------------------------------
+      // -- Missing source file detection ---------------------------------------
       if (options.brokenRefs) {
-        info('Checking for broken attachment references in post content...');
-        const brokenFindings = await detectBrokenRefs(allItems, site.url);
+        info('Checking that each attachment source file resolves...');
+        const brokenFindings = await detectBrokenRefs(allItems);
         findings.push(...brokenFindings);
       }
 
@@ -465,37 +487,39 @@ function hammingDistance(a: bigint, b: bigint): number {
 
 // -- Broken reference detection -----------------------------------------------
 
-async function detectBrokenRefs(items: MediaItem[], _siteUrl: string): Promise<AuditFinding[]> {
-  // Build a set of known attachment URLs for fast lookup.
-  const knownUrls = new Set(items.map((i) => i.url));
+async function detectBrokenRefs(items: MediaItem[]): Promise<AuditFinding[]> {
   const findings: AuditFinding[] = [];
 
-  // Check each attachment URL with a HEAD request.
-  // We're looking for attachments that are registered in WP but whose
-  // underlying file returns a non-200 response.
+  // HEAD each attachment's source URL and flag only DEFINITIVE misses (404/410)
+  // — the file is registered in WP but gone from disk. Transient failures
+  // (network blip, timeout, 5xx) are inconclusive and must NOT be reported as
+  // broken, so we retry once and then skip rather than emit a false positive.
   const CONCURRENCY = 10;
   const chunks = chunkArray(items, CONCURRENCY);
+
+  const isMissing = async (url: string): Promise<number | null> => {
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        const response = await fetch(url, { method: 'HEAD' });
+        if (response.status === 404 || response.status === 410) return response.status;
+        return null; // reachable (or a non-404 error) → not a missing file
+      } catch {
+        // network error — retry once, then treat as inconclusive
+      }
+    }
+    return null;
+  };
 
   for (const chunk of chunks) {
     await Promise.all(
       chunk.map(async (item) => {
-        if (!knownUrls.has(item.url)) return;
-        try {
-          const response = await fetch(item.url, { method: 'HEAD' });
-          if (response.status === 404 || response.status === 410) {
-            findings.push({
-              type: 'broken-ref',
-              attachmentId: item.id,
-              filename: item.filename,
-              detail: `URL returns HTTP ${response.status}: ${item.url}`,
-            });
-          }
-        } catch {
+        const status = await isMissing(item.url);
+        if (status !== null) {
           findings.push({
             type: 'broken-ref',
             attachmentId: item.id,
             filename: item.filename,
-            detail: `URL unreachable: ${item.url}`,
+            detail: `Source file returns HTTP ${status}: ${item.url}`,
           });
         }
       }),

--- a/src/cli/commands/optimize.ts
+++ b/src/cli/commands/optimize.ts
@@ -103,6 +103,7 @@ export function registerOptimizeCommand(program: Command): void {
       'regenerate WordPress thumbnails after replace-in-place (slower)',
     )
     .option('--profile <name>', 'use a named optimization profile (from localpress config)')
+    .option('--force', 'reprocess even if the attachment was already optimized with these settings')
     .action(async (idStrs: string[], options) => {
       const parentOpts = program.opts();
       const config = await loadConfig();
@@ -462,13 +463,6 @@ export function registerOptimizeCommand(program: Command): void {
           const sourceBytes = Buffer.from(await response.arrayBuffer());
           const sourceHash = createHash('sha256').update(sourceBytes).digest('hex');
 
-          // Check idempotency: skip if source hasn't changed since last processing.
-          const lastProcessing = db.getLastProcessing(site.name, item.id, 'optimize');
-          if (lastProcessing?.sourceHash === sourceHash && lastProcessing.status === 'success') {
-            info('    ↳ Skipped (source unchanged since last optimization).');
-            continue;
-          }
-
           // Smart format default: if the user didn't pick a format (no --to,
           // no --profile format) and we have a cached `classify` result for
           // this attachment, route to a sensible default:
@@ -486,6 +480,18 @@ export function registerOptimizeCommand(program: Command): void {
               perItemOpts.toFormat = 'webp';
               info(`    ↳ Smart default: WebP (classified as ${classification})`);
             }
+          }
+
+          // Idempotency: skip only when the current file IS already the output
+          // of a prior successful run with these exact params (see
+          // shouldSkipOptimize). --force bypasses.
+          const lastProcessing = db.getLastProcessing(site.name, item.id, 'optimize');
+          if (
+            !options.force &&
+            shouldSkipOptimize(lastProcessing, sourceHash, JSON.stringify(perItemOpts))
+          ) {
+            info('    ↳ Skipped (already optimized with these settings; use --force to redo).');
+            continue;
           }
 
           // 2. Process through the image engine.
@@ -730,6 +736,28 @@ function formatToMime(format: string): string {
     gif: 'image/gif',
   };
   return map[format] ?? `image/${format}`;
+}
+
+/**
+ * Decide whether an attachment can be skipped as already-optimized.
+ *
+ * The current file is skippable only when it IS the OUTPUT of a prior successful
+ * run with the same params — so we compare the current source hash against the
+ * previous run's `resultHash` (after replace-in-place the server file's hash
+ * equals the last result, not the last source). Consequences:
+ *   - re-running with identical settings is a no-op (no re-compression / no
+ *     generational quality loss / no double-counted stats),
+ *   - a restored/undone file (hash back to the original) re-optimizes,
+ *   - changing any param re-runs.
+ */
+export function shouldSkipOptimize(
+  last: { status: string; resultHash: string | null; paramsJson: string | null } | null,
+  currentHash: string,
+  paramsJson: string,
+): boolean {
+  return (
+    last?.status === 'success' && last.resultHash === currentHash && last.paramsJson === paramsJson
+  );
 }
 
 function recordSuccess(

--- a/src/cli/commands/sites.ts
+++ b/src/cli/commands/sites.ts
@@ -23,6 +23,19 @@ export function tokenizeCommand(input: string): string[] {
   const tokens: string[] = [];
   let current = '';
   let inQuote: '"' | "'" | null = null;
+  // Track whether the current token contained a quote, so an explicitly empty
+  // quoted argument (e.g. `--alt-text ""`) is preserved as an empty token
+  // instead of being dropped — which would make the next flag be consumed as
+  // its value.
+  let sawQuote = false;
+
+  const flush = () => {
+    if (current.length || sawQuote) {
+      tokens.push(current);
+      current = '';
+      sawQuote = false;
+    }
+  };
 
   for (const ch of input) {
     if (inQuote) {
@@ -33,16 +46,14 @@ export function tokenizeCommand(input: string): string[] {
       }
     } else if (ch === '"' || ch === "'") {
       inQuote = ch;
+      sawQuote = true;
     } else if (ch === ' ') {
-      if (current.length) {
-        tokens.push(current);
-        current = '';
-      }
+      flush();
     } else {
       current += ch;
     }
   }
-  if (current.length) tokens.push(current);
+  flush();
   return tokens;
 }
 
@@ -240,6 +251,11 @@ export function registerSitesCommand(program: Command): void {
     .description('Run a localpress command across multiple sites')
     .option('--all-sites', 'run against every configured site')
     .option('--sites <list>', 'comma-separated list of site names')
+    .option(
+      '--timeout <seconds>',
+      'per-site timeout in seconds (0 = no limit; default 3600)',
+      (v) => Number.parseInt(v, 10),
+    )
     .action(async (commandStr: string, options) => {
       const parentOpts = program.opts();
       const config = await loadConfig();
@@ -261,6 +277,20 @@ export function registerSitesCommand(program: Command): void {
         process.exit(ExitCode.InvalidUsage);
       }
 
+      // Forward the run-mode the user set on the parent so per-site children
+      // don't silently fall back to dry-run (which would report success while
+      // writing nothing). These are top-level global flags.
+      const passthroughFlags: string[] = [];
+      if (parentOpts.apply) passthroughFlags.push('--apply');
+      if (parentOpts.dryRun) passthroughFlags.push('--dry-run');
+      if (parentOpts.strict) passthroughFlags.push('--strict');
+      if (parentOpts.yes) passthroughFlags.push('--yes');
+
+      // Bulk cross-site runs routinely exceed the 5-minute MCP default; use a
+      // generous default (1h) and let --timeout override (0 disables).
+      const timeoutMs =
+        typeof options.timeout === 'number' ? options.timeout * 1000 : 60 * 60 * 1000;
+
       const results: {
         site: string;
         exitCode: number;
@@ -271,7 +301,13 @@ export function registerSitesCommand(program: Command): void {
 
       for (const site of names) {
         if (!parentOpts.json) info(`\n── ${site} ──`);
-        const result = await invokeCli({ site, concurrency: parentOpts.concurrency, args });
+        const result = await invokeCli({
+          site,
+          concurrency: parentOpts.concurrency,
+          args,
+          passthroughFlags,
+          timeoutMs,
+        });
         results.push({
           site,
           exitCode: result.exitCode,

--- a/src/cli/commands/undo.ts
+++ b/src/cli/commands/undo.ts
@@ -203,11 +203,6 @@ async function restoreSnapshot(
   }
 
   // Binary snapshot: load blob bytes and replace-in-place.
-  const { SnapshotStore } = await import('../../engine/history/store.ts');
-  // We need the underlying store to read the blob. The resolver doesn't own it,
-  // but we passed it indirectly via the path on the snapshot record. Reuse via
-  // a fresh SnapshotStore is overkill — read the blob directly.
-  void SnapshotStore;
   const { readFileSync } = await import('node:fs');
   if (!snap.blobPath) {
     throw new Error('Binary snapshot is missing its blob path');
@@ -217,8 +212,33 @@ async function restoreSnapshot(
   const replaceAdapter = resolver.tryResolve('replace-in-place');
   if (replaceAdapter) {
     try {
+      // Detect whether the forward operation changed the file format (e.g.
+      // optimize --to webp turned photo.png into photo.webp). If so, undo must
+      // pass newExtension so the adapter renames the file back, restores the
+      // MIME, deletes the wrong-format file, and regenerates thumbnails from
+      // the original bytes — otherwise the original bytes get written under the
+      // new extension and the attachment is left internally inconsistent.
+      const getAdapter = resolver.tryResolve('get');
+      let newExtension: string | undefined;
+      let formatChanged = false;
+      if (getAdapter) {
+        try {
+          const current = await getAdapter.getMedia(snap.wpId);
+          if (current.mimeType !== snap.beforeMeta.mimeType) {
+            formatChanged = true;
+            const { extname } = await import('node:path');
+            const origExt = extname(snap.beforeMeta.filename);
+            if (origExt) newExtension = origExt;
+          }
+        } catch {
+          // Couldn't read current state — fall back to a same-format restore.
+        }
+      }
+
       await replaceAdapter.replaceInPlace(snap.wpId, bytes, {
         newMimeType: snap.beforeMeta.mimeType,
+        newExtension,
+        regenerateThumbnails: formatChanged,
       });
       // Also restore metadata fields that may have changed.
       const metaAdapter = resolver.tryResolve('update-meta');
@@ -229,6 +249,11 @@ async function restoreSnapshot(
           caption: snap.beforeMeta.caption,
           description: snap.beforeMeta.description,
         });
+      }
+      if (formatChanged) {
+        warn(
+          `    ⚠ Restored to ${snap.beforeMeta.filename}. If the original optimize rewrote post references to the new URL, re-check them (references --update-to).`,
+        );
       }
       return;
     } catch (err) {

--- a/src/cli/mcp/invoke.ts
+++ b/src/cli/mcp/invoke.ts
@@ -35,8 +35,17 @@ export interface InvokeOptions {
   args: string[];
   /** Working directory for the child process. */
   cwd?: string;
-  /** Timeout in ms; child is killed if exceeded. Default: 5 minutes. */
+  /**
+   * Timeout in ms; child is killed if exceeded. Default: 5 minutes. Pass 0 to
+   * disable the timeout entirely (bulk cross-site runs can exceed any bound).
+   */
   timeoutMs?: number;
+  /**
+   * Extra top-level flags to forward before the subcommand (e.g. `--apply`,
+   * `--dry-run`, `--strict`). Used by `sites run` so per-site children honor the
+   * run mode the user set on the parent.
+   */
+  passthroughFlags?: string[];
 }
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
@@ -56,6 +65,9 @@ export async function invokeCli(opts: InvokeOptions): Promise<CliResult> {
   if (opts.site) topLevelFlags.push('--site', opts.site);
   if (typeof opts.concurrency === 'number') {
     topLevelFlags.push('--concurrency', String(opts.concurrency));
+  }
+  for (const flag of opts.passthroughFlags ?? []) {
+    if (!baseArgs.includes(flag)) topLevelFlags.push(flag);
   }
   const argsWithSite = [...topLevelFlags, ...baseArgs];
 
@@ -77,10 +89,23 @@ export async function invokeCli(opts: InvokeOptions): Promise<CliResult> {
     let stderrBuf = '';
     let timedOut = false;
 
-    const timer = setTimeout(() => {
-      timedOut = true;
-      child.kill('SIGTERM');
-    }, opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+    const effectiveTimeout = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    let killTimer: ReturnType<typeof setTimeout> | null = null;
+    // effectiveTimeout === 0 disables the timeout (unbounded bulk runs).
+    const timer =
+      effectiveTimeout > 0
+        ? setTimeout(() => {
+            timedOut = true;
+            child.kill('SIGTERM');
+            // Escalate to SIGKILL if the child ignores SIGTERM, so a stuck
+            // child can never hang the parent forever.
+            killTimer = setTimeout(() => child.kill('SIGKILL'), 5000);
+          }, effectiveTimeout)
+        : null;
+    const clearTimers = () => {
+      if (timer) clearTimeout(timer);
+      if (killTimer) clearTimeout(killTimer);
+    };
 
     child.stdout.on('data', (chunk) => {
       stdoutBuf += chunk.toString('utf8');
@@ -90,7 +115,7 @@ export async function invokeCli(opts: InvokeOptions): Promise<CliResult> {
     });
 
     child.on('error', (err) => {
-      clearTimeout(timer);
+      clearTimers();
       resolve({
         exitCode: -1,
         stdout: null,
@@ -100,7 +125,7 @@ export async function invokeCli(opts: InvokeOptions): Promise<CliResult> {
     });
 
     child.on('close', (code) => {
-      clearTimeout(timer);
+      clearTimers();
       const exitCode = code ?? -1;
       let parsed: unknown = stdoutBuf;
 
@@ -127,9 +152,7 @@ export async function invokeCli(opts: InvokeOptions): Promise<CliResult> {
       resolve({
         exitCode,
         stdout: parsed,
-        stderr: timedOut
-          ? `${stderrBuf}\n[timed out after ${opts.timeoutMs ?? DEFAULT_TIMEOUT_MS}ms]`
-          : stderrBuf,
+        stderr: timedOut ? `${stderrBuf}\n[timed out after ${effectiveTimeout}ms]` : stderrBuf,
         ok: exitCode === 0,
       });
     });

--- a/src/engine/preview/quick-view.ts
+++ b/src/engine/preview/quick-view.ts
@@ -54,6 +54,13 @@ export async function quickViewInBrowser(options: QuickViewOptions): Promise<voi
     hostname: '127.0.0.1',
     fetch(req, server) {
       const url = new URL(req.url);
+      // Only serve the loopback origin (defeats DNS rebinding). quick-view is
+      // read-only (no mutation endpoint), so no token is needed beyond this.
+      const host = req.headers.get('host') ?? '';
+      const listenPort = server.port ?? state.server?.port;
+      if (host !== `127.0.0.1:${listenPort}` && host !== `localhost:${listenPort}`) {
+        return new Response('Forbidden', { status: 403 });
+      }
       if (url.pathname === '/ws' && req.headers.get('upgrade') === 'websocket') {
         const upgraded = server.upgrade(req, { data: {} });
         return upgraded ? undefined : new Response('Upgrade failed', { status: 500 });
@@ -176,5 +183,11 @@ function openBrowser(url: string): void {
   const cmd =
     process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'cmd' : 'xdg-open';
   const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url];
-  spawn(cmd, args, { detached: true, stdio: 'ignore' }).unref();
+  try {
+    const child = spawn(cmd, args, { detached: true, stdio: 'ignore' });
+    child.on('error', () => {});
+    child.unref();
+  } catch {
+    // ignore — best-effort browser launch
+  }
 }

--- a/src/engine/preview/server.ts
+++ b/src/engine/preview/server.ts
@@ -18,7 +18,32 @@
  */
 
 import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { info, warn } from '../../cli/utils/output.ts';
+
+/**
+ * Client-side bootstrap injected into every served page. It reads the session
+ * token from the URL fragment (never sent to the server or logged) and attaches
+ * it to every same-origin `fetch` and WebSocket, so the real UI is authorized
+ * without editing any of the UI code — while a cross-origin page (which can't
+ * read our fragment) cannot forge an authorized mutation.
+ */
+function authBootstrap(): string {
+  return `<script>(function(){
+  var t=(location.hash.match(/token=([A-Za-z0-9-]+)/)||[])[1]||'';
+  var of=window.fetch;
+  window.fetch=function(i,init){init=init||{};var h=new Headers(init.headers||{});h.set('X-Preview-Token',t);init.headers=h;return of(i,init);};
+  var OW=window.WebSocket;
+  function PW(u,p){var s=u.indexOf('?')<0?'?':'&';return new OW(u+s+'token='+encodeURIComponent(t),p);}
+  PW.prototype=OW.prototype;window.WebSocket=PW;
+})();</script>`;
+}
+
+/** Image endpoints loaded via <img src> can't carry a custom header, so they
+ * are token-exempt (still protected by the Host check + absence of CORS). */
+function isTokenExempt(method: string, pathname: string): boolean {
+  return method === 'GET' && (pathname === '/api/source' || pathname === '/api/result');
+}
 
 export interface PreviewServerOptions {
   /** Port to listen on. 0 = auto-assign. */
@@ -46,6 +71,13 @@ export interface PreviewServerOptions {
   html: string;
   /** Extra metadata to include in the /api/meta response (e.g. profiles). */
   extraMeta?: Record<string, unknown>;
+  /**
+   * Called once the server is listening, with the bound port and session token.
+   * The token is only secret from *other* processes/pages, not the launching
+   * CLI — this hook exists so callers (and tests) can construct authorized
+   * requests or print the URL. Optional.
+   */
+  onReady?: (info: { port: number; token: string; url: string }) => void;
 }
 
 export interface ProcessResult {
@@ -77,6 +109,10 @@ export async function startPreviewServer(
 ): Promise<{ applied: boolean; result: ApplyResult | null }> {
   const port = options.port ?? 0;
   const timeoutMs = options.timeoutMs ?? 10 * 60 * 1000;
+  // Per-session secret. Delivered to the browser via the URL fragment and
+  // required on every mutating endpoint so no other local process or web page
+  // can drive the preview (e.g. POST /api/apply to overwrite the attachment).
+  const token = randomUUID();
 
   // Mutable state shared between the fetch handler and lifecycle management.
   const state: {
@@ -86,6 +122,8 @@ export async function startPreviewServer(
     server: ReturnType<typeof Bun.serve> | null;
     wsConnected: boolean;
     wsHeartbeatId: ReturnType<typeof setInterval> | null;
+    closeGraceId: ReturnType<typeof setTimeout> | null;
+    shuttingDown: boolean;
   } = {
     lastResultBytes: null,
     lastResultMimeType: null,
@@ -93,6 +131,8 @@ export async function startPreviewServer(
     server: null,
     wsConnected: false,
     wsHeartbeatId: null,
+    closeGraceId: null,
+    shuttingDown: false,
   };
 
   let resolvePromise: (value: { applied: boolean; result: ApplyResult | null }) => void;
@@ -100,9 +140,22 @@ export async function startPreviewServer(
     resolvePromise = resolve;
   });
 
+  // The promise must resolve exactly once. Bun's `server.stop(true)` fires the
+  // WebSocket close handler synchronously, so a naive apply path would let the
+  // close handler's {applied:false} win the race over the real {applied:true}.
+  let resolved = false;
+  const resolveOnce = (value: { applied: boolean; result: ApplyResult | null }) => {
+    if (!resolved) {
+      resolved = true;
+      resolvePromise(value);
+    }
+  };
+
   const shutdown = () => {
+    state.shuttingDown = true;
     if (state.timeoutId) clearTimeout(state.timeoutId);
     if (state.wsHeartbeatId) clearInterval(state.wsHeartbeatId);
+    if (state.closeGraceId) clearTimeout(state.closeGraceId);
     state.server?.stop(true);
   };
 
@@ -115,15 +168,37 @@ export async function startPreviewServer(
     fetch: async (req, server) => {
       const url = new URL(req.url);
 
-      // WebSocket upgrade for heartbeat.
+      // Reject anything not addressed to the loopback origin. This defeats DNS
+      // rebinding (the attacker's rebound hostname would appear in Host) and
+      // stray cross-origin navigations.
+      const host = req.headers.get('host') ?? '';
+      const listenPort = server.port ?? state.server?.port;
+      if (host !== `127.0.0.1:${listenPort}` && host !== `localhost:${listenPort}`) {
+        return new Response('Forbidden', { status: 403 });
+      }
+
+      // WebSocket upgrade for heartbeat — token via query string.
       if (url.pathname === '/ws' && req.headers.get('upgrade') === 'websocket') {
+        if (url.searchParams.get('token') !== token) {
+          return new Response('Forbidden', { status: 403 });
+        }
         const upgraded = server.upgrade(req, { data: {} });
         return upgraded ? undefined : new Response('WebSocket upgrade failed', { status: 500 });
       }
 
-      // Serve the UI.
+      // Require the session token on every mutating/data endpoint. Image
+      // endpoints loaded via <img src> can't send a header, so they're exempt
+      // (still Host-checked and not CORS-readable cross-origin).
+      if (url.pathname.startsWith('/api/') && !isTokenExempt(req.method, url.pathname)) {
+        if (req.headers.get('x-preview-token') !== token) {
+          return new Response('Forbidden', { status: 403 });
+        }
+      }
+
+      // Serve the UI (with the auth bootstrap injected into <head>).
       if (url.pathname === '/' && req.method === 'GET') {
-        return new Response(options.html, {
+        const html = options.html.replace('<head>', `<head>${authBootstrap()}`);
+        return new Response(html, {
           headers: { 'Content-Type': 'text/html; charset=utf-8' },
         });
       }
@@ -190,11 +265,12 @@ export async function startPreviewServer(
           info('  Applying optimized image to WordPress...');
           const result = await options.onApply(state.lastResultBytes, state.lastResultMimeType);
           info(`  ✓ Applied successfully (${result.message})`);
-          // Delay shutdown to ensure the response is fully sent to the browser
-          // before the server closes the TCP connection.
+          // Resolve BEFORE shutting the server down: stop(true) fires the WS
+          // close handler synchronously, and resolveOnce must record the
+          // successful apply, not the close handler's cancel.
           setTimeout(() => {
+            resolveOnce({ applied: true, result });
             shutdown();
-            resolvePromise({ applied: true, result });
           }, 500);
           return new Response(JSON.stringify(result), {
             headers: { 'Content-Type': 'application/json' },
@@ -211,8 +287,8 @@ export async function startPreviewServer(
 
       // Cancel and shut down.
       if (url.pathname === '/api/cancel' && req.method === 'POST') {
+        resolveOnce({ applied: false, result: null });
         shutdown();
-        resolvePromise({ applied: false, result: null });
         return new Response(JSON.stringify({ ok: true }), {
           headers: { 'Content-Type': 'application/json' },
         });
@@ -240,41 +316,65 @@ export async function startPreviewServer(
     websocket: {
       open() {
         state.wsConnected = true;
+        // A reconnect (page reload) landed within the grace window — keep alive.
+        if (state.closeGraceId) {
+          clearTimeout(state.closeGraceId);
+          state.closeGraceId = null;
+        }
       },
       message() {
         // Heartbeat pong — client is alive.
       },
       close() {
         state.wsConnected = false;
-        info('  Browser tab closed. Shutting down preview server.');
-        shutdown();
-        resolvePromise({ applied: false, result: null });
+        if (state.shuttingDown) return; // intentional shutdown — nothing to do
+        // A reload closes then immediately reopens the socket. Only treat the
+        // close as "the user left" if no new socket connects within the window.
+        if (state.closeGraceId) clearTimeout(state.closeGraceId);
+        state.closeGraceId = setTimeout(() => {
+          if (!state.wsConnected && !state.shuttingDown) {
+            info('  Browser tab closed. Shutting down preview server.');
+            resolveOnce({ applied: false, result: null });
+            shutdown();
+          }
+        }, 1500);
       },
     },
   });
 
-  const actualPort = state.server.port;
+  const actualPort = state.server.port ?? 0;
   const previewUrl = `http://127.0.0.1:${actualPort}`;
 
   info(`  Preview server running at ${previewUrl}`);
   info('  Opening browser...');
 
-  openBrowser(previewUrl);
+  options.onReady?.({ port: actualPort, token, url: previewUrl });
+
+  // The token rides in the URL fragment: never sent to the server, never logged.
+  openBrowser(`${previewUrl}/#token=${token}`);
 
   // Auto-shutdown timeout.
   state.timeoutId = setTimeout(() => {
     warn('Preview server timed out. Shutting down.');
+    resolveOnce({ applied: false, result: null });
     shutdown();
-    resolvePromise({ applied: false, result: null });
   }, timeoutMs);
 
   return done;
 }
 
-/** Open a URL in the default browser. */
+/** Open a URL in the default browser. Best-effort — never throws. */
 function openBrowser(url: string): void {
   const cmd =
     process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'cmd' : 'xdg-open';
   const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url];
-  spawn(cmd, args, { detached: true, stdio: 'ignore' }).unref();
+  try {
+    const child = spawn(cmd, args, { detached: true, stdio: 'ignore' });
+    // A missing launcher (headless/CI) emits an async 'error'; swallow it so it
+    // doesn't crash the process. The user can still open the printed URL.
+    child.on('error', () => {});
+    child.unref();
+  } catch {
+    // ignore
+  }
 }

--- a/test/unit/optimize-idempotency.test.ts
+++ b/test/unit/optimize-idempotency.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Unit tests for the optimize idempotency decision (#97).
+ *
+ * The skip must compare the current file hash against the PREVIOUS OUTPUT
+ * (resultHash), not the previous source — otherwise a re-run re-compresses
+ * every image, and an undone file can never be re-optimized.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { shouldSkipOptimize } from '../../src/cli/commands/optimize.ts';
+
+const params = JSON.stringify({ toFormat: 'webp', quality: 80 });
+
+describe('shouldSkipOptimize', () => {
+  test('skips when current file is the prior output with the same params', () => {
+    const last = { status: 'success', resultHash: 'OUT', paramsJson: params };
+    // After replace-in-place, the server file hash == the previous resultHash.
+    expect(shouldSkipOptimize(last, 'OUT', params)).toBe(true);
+  });
+
+  test('does NOT skip when the file still equals the original source', () => {
+    // e.g. right after an undo restored the original bytes.
+    const last = { status: 'success', resultHash: 'OUT', paramsJson: params };
+    expect(shouldSkipOptimize(last, 'ORIGINAL', params)).toBe(false);
+  });
+
+  test('does NOT skip when params differ', () => {
+    const last = { status: 'success', resultHash: 'OUT', paramsJson: params };
+    const otherParams = JSON.stringify({ toFormat: 'avif', quality: 50 });
+    expect(shouldSkipOptimize(last, 'OUT', otherParams)).toBe(false);
+  });
+
+  test('does NOT skip on a failed prior run, or with no history', () => {
+    expect(
+      shouldSkipOptimize(
+        { status: 'failure', resultHash: 'OUT', paramsJson: params },
+        'OUT',
+        params,
+      ),
+    ).toBe(false);
+    expect(shouldSkipOptimize(null, 'OUT', params)).toBe(false);
+  });
+});

--- a/test/unit/preview-server.test.ts
+++ b/test/unit/preview-server.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Integration tests for the preview server's security + lifecycle fixes:
+ *   - #106: mutating endpoints require the session token; a forged Host is
+ *     rejected (DNS-rebind guard).
+ *   - #105: a successful apply resolves { applied: true } (previously the WS
+ *     close race made every apply report applied:false).
+ *
+ * Runs a real Bun.serve on loopback. Requests use raw sockets with
+ * `Connection: close` (Bun's fetch keep-alive pool reuses a socket the server
+ * closes between requests, which is unrelated to what we're testing). The
+ * browser open is a detached, unref'd spawn that no-ops (never throws) in CI.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { connect } from 'node:net';
+import {
+  type ApplyResult,
+  type ProcessResult,
+  startPreviewServer,
+} from '../../src/engine/preview/server.ts';
+
+interface Harness {
+  port: number;
+  token: string;
+  done: Promise<{ applied: boolean; result: ApplyResult | null }>;
+}
+
+// onReady fires synchronously during startPreviewServer() (before its first
+// await), so we can capture the port/token in the same tick.
+function launch(): Harness {
+  let port = 0;
+  let token = '';
+  const done = startPreviewServer({
+    sourceBytes: Buffer.from('source-image-bytes'),
+    filename: 'photo.jpg',
+    mimeType: 'image/jpeg',
+    wpId: 42,
+    mode: 'optimize',
+    html: '<!DOCTYPE html><html><head></head><body>preview</body></html>',
+    onProcess: async (): Promise<ProcessResult> => ({
+      bytes: Buffer.from('processed-bytes'),
+      mimeType: 'image/webp',
+      stats: {},
+    }),
+    onApply: async (): Promise<ApplyResult> => ({ wpId: 42, message: 'applied' }),
+    onReady: (info) => {
+      port = info.port;
+      token = info.token;
+    },
+  });
+  if (!token) throw new Error('onReady did not fire synchronously');
+  return { port, token, done };
+}
+
+interface RawResponse {
+  status: number;
+  body: string;
+}
+
+/** Send one raw HTTP/1.1 request over a fresh socket (Connection: close). */
+function raw(
+  port: number,
+  method: string,
+  path: string,
+  opts: { host?: string; headers?: Record<string, string>; body?: string } = {},
+): Promise<RawResponse> {
+  return new Promise((resolve, reject) => {
+    const host = opts.host ?? `127.0.0.1:${port}`;
+    const body = opts.body ?? '';
+    const lines = [`${method} ${path} HTTP/1.1`, `Host: ${host}`, 'Connection: close'];
+    for (const [k, v] of Object.entries(opts.headers ?? {})) lines.push(`${k}: ${v}`);
+    if (body) lines.push(`Content-Length: ${Buffer.byteLength(body)}`);
+    const sock = connect(port, '127.0.0.1', () => {
+      sock.write(`${lines.join('\r\n')}\r\n\r\n${body}`);
+    });
+    let data = '';
+    sock.on('data', (d) => {
+      data += d.toString();
+    });
+    sock.on('end', () => {
+      const m = data.match(/^HTTP\/1\.1 (\d{3})/);
+      const sep = data.indexOf('\r\n\r\n');
+      resolve({ status: m ? Number(m[1]) : 0, body: sep >= 0 ? data.slice(sep + 4) : '' });
+    });
+    sock.on('error', reject);
+  });
+}
+
+describe('preview server — auth (#106)', () => {
+  test('rejects /api/apply without the session token', async () => {
+    const h = launch();
+    const res = await raw(h.port, 'POST', '/api/apply');
+    expect(res.status).toBe(403);
+    await raw(h.port, 'POST', '/api/cancel', { headers: { 'X-Preview-Token': h.token } });
+    await h.done;
+  });
+
+  test('rejects a request with a foreign Host header (DNS-rebind guard)', async () => {
+    const h = launch();
+    // Matching loopback Host is accepted (serves the UI shell)...
+    expect((await raw(h.port, 'GET', '/')).status).toBe(200);
+    // ...a rebound attacker hostname is rejected before any handler runs.
+    expect((await raw(h.port, 'GET', '/api/meta', { host: 'evil.example.com' })).status).toBe(403);
+    await raw(h.port, 'POST', '/api/cancel', { headers: { 'X-Preview-Token': h.token } });
+    await h.done;
+  });
+
+  test('injects the auth bootstrap into the served HTML', async () => {
+    const h = launch();
+    const res = await raw(h.port, 'GET', '/');
+    expect(res.body).toContain('X-Preview-Token');
+    await raw(h.port, 'POST', '/api/cancel', { headers: { 'X-Preview-Token': h.token } });
+    await h.done;
+  });
+});
+
+describe('preview server — apply resolves applied:true (#105)', () => {
+  test('a token-authorized process→apply resolves { applied: true }', async () => {
+    const h = launch();
+    const auth = { 'X-Preview-Token': h.token };
+
+    const proc = await raw(h.port, 'POST', '/api/process', {
+      headers: { ...auth, 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    expect(proc.status).toBe(200);
+
+    const apply = await raw(h.port, 'POST', '/api/apply', { headers: auth });
+    expect(apply.status).toBe(200);
+
+    const outcome = await h.done;
+    expect(outcome.applied).toBe(true);
+    expect(outcome.result?.wpId).toBe(42);
+  });
+});

--- a/test/unit/sites-run.test.ts
+++ b/test/unit/sites-run.test.ts
@@ -42,6 +42,28 @@ describe('tokenizeCommand', () => {
   test('trims extra spaces between tokens', () => {
     expect(tokenizeCommand('audit  --json')).toEqual(['audit', '--json']);
   });
+
+  test('preserves an explicitly empty quoted argument (#104)', () => {
+    // Without this, `--alt-text ""` drops the empty token and the following
+    // flag is consumed as its value.
+    expect(tokenizeCommand('metadata 42 --alt-text "" --title Cat')).toEqual([
+      'metadata',
+      '42',
+      '--alt-text',
+      '',
+      '--title',
+      'Cat',
+    ]);
+  });
+
+  test('empty single-quoted argument is preserved too', () => {
+    expect(tokenizeCommand("metadata 42 --caption ''")).toEqual([
+      'metadata',
+      '42',
+      '--caption',
+      '',
+    ]);
+  });
 });
 
 // -- aggregateExitCode --------------------------------------------------------

--- a/test/unit/ssh.test.ts
+++ b/test/unit/ssh.test.ts
@@ -11,9 +11,35 @@
 import { describe, expect, test } from 'bun:test';
 
 import { AdapterResolver } from '../../src/adapters/resolver.ts';
-import { buildSshArgs, sshDestination } from '../../src/adapters/ssh.ts';
+import { buildSshArgs, shellQuote, sshDestination } from '../../src/adapters/ssh.ts';
 import { isWpCliAvailableForSite } from '../../src/adapters/wp-cli.ts';
 import type { SiteConfig, SshConfig } from '../../src/types.ts';
+
+// -- shellQuote ---------------------------------------------------------------
+
+describe('shellQuote', () => {
+  test('wraps a plain value in single quotes', () => {
+    expect(shellQuote('hello')).toBe("'hello'");
+  });
+
+  test('neutralizes shell metacharacters (no unquoted injection)', () => {
+    for (const dangerous of ['a; rm -rf ~', '$(whoami)', '`id`', 'a && b', 'a | b', 'a > f']) {
+      const quoted = shellQuote(dangerous);
+      // Everything stays inside one single-quoted string → inert to the shell.
+      expect(quoted.startsWith("'")).toBe(true);
+      expect(quoted.endsWith("'")).toBe(true);
+    }
+  });
+
+  test("escapes embedded single quotes via the '\\'' idiom", () => {
+    // O'Brien → 'O'\''Brien'
+    expect(shellQuote("O'Brien")).toBe("'O'\\''Brien'");
+  });
+
+  test('a title with a double quote does not break the argument', () => {
+    expect(shellQuote('A "wide" shot')).toBe('\'A "wide" shot\'');
+  });
+});
 
 // -- Test fixtures ------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Follow-up to the v2.1.0 trust release (#136). This PR completes the deferred **trust** items and folds in the next **correctness/security** batch from the audit — shipped together as v2.2.0 since they share the one working branch.

`bun typecheck`, `bun lint`, and the unit suite (**237 pass / 3 env-skipped / 0 fail**, +14 new assertions) are all green.

---

## Part 1 — Trust story (the deferred items)

### Undo correctness — #91 (critical)
`undo` after a format-changing optimize (e.g. png→webp) previously wrote the original bytes *into the new-extension file* and left the attachment inconsistent. It now detects the format change, fetches the current attachment, and passes `newExtension` + thumbnail regeneration so the file is renamed back, MIME restored, wrong-format file removed, and thumbnails rebuilt. Warns to re-check references.

### Optimize idempotency — #97 (high)
The skip compared against the previous *source* hash, so after replace-in-place it never skipped — re-running `optimize --all` re-compressed the whole library and after `undo` an image could never be re-optimized. Now it compares the current file against the previous run's `resultHash` **with matching params**; adds **`optimize --force`**; extracted a pure, unit-tested `shouldSkipOptimize`.

### Preview server — #105 / #106 (high / security)
- **Apply reports success (#105):** `resolveOnce` + resolve-before-shutdown fixes the WS-close race that made every apply report "cancelled"; F5 reload no longer kills the session.
- **Endpoints authenticated (#106):** per-session token (URL fragment, never sent to the server) required on mutating endpoints + `Host`-header check defeats other local processes, cross-origin pages, and DNS rebinding. Injected client-side with **zero UI-code changes**; quick-view gets the Host check too.
- Browser launch is best-effort and never throws in headless environments.

---

## Part 2 — Correctness & security batch

### WP-CLI shell hardening — #112
Every interpolated value (titles, alt text, captions, descriptions, paths, and the `_wp_attachment_metadata` JSON) is now single-quote escaped via a shared `shellQuote` helper — content with quotes/`$`/backticks/`;` can't break the command or inject execution. Fixes the broken `\'`-in-single-quotes JSON escaping that silently corrupted metadata on apostrophes, groups the `pruneOrphans` `find` predicate so directories aren't reported as orphan files, and makes temp filenames collision-proof.

### audit correctness — #111
- No longer **crashes on a library whose size is an exact multiple of 100** (treats the resulting 400 as "no more pages").
- **`--unattached` is now implemented** (attachments with parent post 0) instead of silently returning nothing — added `MediaItem.parentPost`, mapped from the REST `post` field.
- **`--broken-refs` re-documented and rewritten** as an honest missing-source-file probe (404/410) that retries once and never reports transient network errors as broken.
- Duplicate detection is **excluded from a bare `audit`** (it downloaded every image's full bytes).

### sites run completion — #104
- **Forwards `--apply` / `--dry-run` / `--strict` / `--yes`** to per-site children — previously a cross-site `optimize --apply` silently ran as a dry-run while reporting "N/N succeeded".
- Per-child timeout defaults to **1 hour with a `--timeout` override** (`0` disables), and SIGTERM escalates to SIGKILL so a stuck child can't hang the run.
- The command tokenizer preserves an explicitly **empty quoted argument** (`--alt-text ""`).

---

## Tests
- Preview server integration (auth + apply-race via raw sockets), optimize idempotency decision, `shouldSkipOptimize`, `shellQuote` escaping, and the empty-quoted-arg tokenizer case.

Closes #91, #97, #104, #105, #106, #111, #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KLqDSup6HVMJk8vK1TXjS