### PR TITLE
fix(undo): treat REST-only upload-as-new restore as partial, not restored

### DIFF
--- a/src/cli/commands/undo.ts
+++ b/src/cli/commands/undo.ts
@@ -48,8 +48,22 @@ interface UndoResult {
   attachmentId: number;
   operation: string;
   kind: 'binary' | 'metadata-only';
-  status: 'restored' | 'failed' | 'skipped';
+  status: 'restored' | 'partial' | 'failed' | 'skipped';
   reason?: string;
+  /** For 'partial': the new attachment ID created by the upload-as-new fallback. */
+  newAttachmentId?: number;
+}
+
+/**
+ * Result of applying one snapshot.
+ *   - 'restored': the live attachment now holds the original bytes/metadata.
+ *   - 'partial':  replace-in-place was unavailable, so the original was uploaded
+ *     as a NEW attachment. The target attachment is unchanged and references
+ *     still point at it — so the snapshot must stay un-restored for a later retry.
+ */
+export interface RestoreOutcome {
+  status: 'restored' | 'partial';
+  newAttachmentId?: number;
 }
 
 export function registerUndoCommand(program: Command): void {
@@ -164,7 +178,26 @@ export function registerUndoCommand(program: Command): void {
       for (const snap of snapshots) {
         info(`  Restoring snapshot #${snap.id} (attachment #${snap.wpId}, ${snap.operation})...`);
         try {
-          await restoreSnapshot(snap, resolver, store, parentOpts.strict);
+          const outcome = await restoreSnapshot(snap, resolver, store, parentOpts.strict);
+
+          if (outcome.status === 'partial') {
+            // Upload-as-new fallback (REST-only): the target attachment is
+            // unchanged, so DON'T consume the snapshot — leave it un-restored so
+            // the user can retry after adding a replace-in-place capability
+            // (SSH/WP-CLI). References still point at the original ID.
+            results.push({
+              snapshotId: snap.id,
+              attachmentId: snap.wpId,
+              operation: snap.operation,
+              kind: snap.kind,
+              status: 'partial',
+              newAttachmentId: outcome.newAttachmentId,
+              reason: `original re-uploaded as new attachment #${outcome.newAttachmentId}; attachment #${snap.wpId} is unchanged and references still point at it. Retry with a replace-in-place backend (SSH/WP-CLI), or rewrite refs: localpress references ${snap.wpId} --update-to ${outcome.newAttachmentId}`,
+            });
+            info('    ↳ partial (snapshot kept for retry)');
+            continue;
+          }
+
           store.markRestored(snap.id);
           // The restored bytes no longer match what processing_history recorded
           // as this operation's output, so exclude that row from future stats
@@ -193,10 +226,20 @@ export function registerUndoCommand(program: Command): void {
         }
       }
 
+      const restored = results.filter((r) => r.status === 'restored').length;
+      const partial = results.filter((r) => r.status === 'partial').length;
+
       if (parentOpts.json) {
-        printJson({ restored: results.length - failures, failures, results });
+        printJson({ restored, partial, failures, results });
       } else {
-        info(`\n  Done: ${results.length - failures} restored, ${failures} failed.`);
+        const partialNote = partial > 0 ? `, ${partial} partial` : '';
+        info(`\n  Done: ${restored} restored${partialNote}, ${failures} failed.`);
+        if (partial > 0) {
+          warn(
+            '  ⚠ Partial restores uploaded the original as a new attachment; the ' +
+              'snapshot was kept so you can retry with a replace-in-place backend.',
+          );
+        }
       }
 
       db.close();
@@ -204,13 +247,20 @@ export function registerUndoCommand(program: Command): void {
     });
 }
 
-/** Apply a single snapshot back to WordPress. Throws on failure. */
+/**
+ * Apply a single snapshot back to WordPress. Throws on failure.
+ *
+ * Returns `{ status: 'restored' }` when the live attachment was updated in
+ * place, or `{ status: 'partial', newAttachmentId }` when replace-in-place was
+ * unavailable and the original had to be uploaded as a new attachment (the
+ * caller must NOT mark the snapshot restored in that case).
+ */
 export async function restoreSnapshot(
   snap: SnapshotRecord,
   resolver: ResolverLike,
   store: SnapshotStore,
   strict: boolean,
-): Promise<void> {
+): Promise<RestoreOutcome> {
   if (snap.kind === 'metadata-only') {
     const metaAdapter: WpBackend = resolver.resolve('update-meta');
     await metaAdapter.updateMetadata(snap.wpId, {
@@ -220,7 +270,7 @@ export async function restoreSnapshot(
       description: snap.beforeMeta.description,
       ...(snap.beforeMeta.slug !== undefined ? { slug: snap.beforeMeta.slug } : {}),
     });
-    return;
+    return { status: 'restored' };
   }
 
   // Binary snapshot: load blob bytes (existence/size/hash verified by readBlob)
@@ -269,7 +319,7 @@ export async function restoreSnapshot(
           ...(snap.beforeMeta.slug !== undefined ? { slug: snap.beforeMeta.slug } : {}),
         });
       }
-      return;
+      return { status: 'restored' };
     } catch (err) {
       if (err instanceof CapabilityUnavailableError && !strict) {
         // Fall through to upload-new fallback.
@@ -291,4 +341,5 @@ export async function restoreSnapshot(
   warn(
     `    ⚠ Original uploaded as new attachment #${uploaded.id} (in-place replacement not available). Update references manually if needed.`,
   );
+  return { status: 'partial', newAttachmentId: uploaded.id };
 }

--- a/test/integration/wp-rest-commands.test.ts
+++ b/test/integration/wp-rest-commands.test.ts
@@ -114,20 +114,24 @@ describe.skipIf(!canRun)('CLI subprocess integration', () => {
         expect(undoResult.exitCode).toBe(0);
         const undoJson = JSON.parse(undoResult.stdout) as {
           restored: number;
+          partial: number;
           failures: number;
-          results: Array<{ status: string; attachmentId: number }>;
+          results: Array<{ status: string; attachmentId: number; newAttachmentId?: number }>;
         };
         expect(undoJson.failures).toBe(0);
-        expect(undoJson.restored).toBe(1);
-        expect(undoJson.results[0].status).toBe('restored');
+        // REST-only site: no replace-in-place, so undo of a binary snapshot
+        // uploads the original as a NEW attachment and reports 'partial' — the
+        // snapshot is intentionally kept un-restored for a later retry (#119).
+        expect(undoJson.restored).toBe(0);
+        expect(undoJson.partial).toBe(1);
+        expect(undoJson.results[0].status).toBe('partial');
         expect(undoJson.results[0].attachmentId).toBe(uploaded.id);
+        expect(undoJson.results[0].newAttachmentId).toBeGreaterThan(0);
 
-        // The restore itself also falls back to upload-as-new on REST-only
-        // sites — capture that attachment ID from the warn() line for cleanup.
-        const warnLines = parseStderrLines(undoResult.stderr);
-        const restoreWarn = warnLines.find((l) => /uploaded as new attachment/i.test(l.message));
-        const match = restoreWarn?.message.match(/#(\d+)/);
-        if (match) restoredAttachmentIds.push(Number(match[1]));
+        // Capture the upload-as-new attachment ID (surfaced in the JSON) for cleanup.
+        if (undoJson.results[0].newAttachmentId) {
+          restoredAttachmentIds.push(undoJson.results[0].newAttachmentId);
+        }
       } finally {
         await adapter.delete(uploaded.id, { force: true }).catch(() => {});
         for (const id of restoredAttachmentIds) {

--- a/test/unit/undo.test.ts
+++ b/test/unit/undo.test.ts
@@ -213,4 +213,78 @@ describe('restoreSnapshot', () => {
 
     expect(warnedLines.some((line) => line.includes('--scope full'))).toBe(false);
   });
+
+  test('in-place restore reports status "restored"', async () => {
+    const snap = captureBinarySnapshot('photo.jpg', 'image/jpeg', Buffer.from('bytes'));
+    const backend = makeFakeBackend({
+      getMedia: async (id): Promise<MediaItem> => ({
+        id,
+        title: 'photo',
+        filename: 'photo.jpg',
+        url: 'https://example.test/photo.jpg',
+        mimeType: 'image/jpeg',
+        uploadedAt: '2024-01-01',
+      }),
+      replaceInPlace: async (id): Promise<MediaItem> => ({
+        id,
+        title: 'photo',
+        filename: 'photo.jpg',
+        url: 'https://example.test/photo.jpg',
+        mimeType: 'image/jpeg',
+        uploadedAt: '2024-01-01',
+      }),
+    });
+    const resolver: ResolverLike = {
+      resolve: (c) => {
+        if (c === 'get' || c === 'update-meta') return backend;
+        throw new Error(`unexpected resolve('${c}')`);
+      },
+      tryResolve: (c) => (c === 'replace-in-place' || c === 'update-meta' ? backend : null),
+    };
+
+    const outcome = await restoreSnapshot(snap, resolver, store, false);
+    expect(outcome.status).toBe('restored');
+    expect(outcome.newAttachmentId).toBeUndefined();
+  });
+
+  test('REST-only fallback reports status "partial" with the new attachment ID (regression #119)', async () => {
+    const snap = captureBinarySnapshot('photo.jpg', 'image/jpeg', Buffer.from('original bytes'));
+
+    let uploadedBytes: Buffer | undefined;
+    const uploadBackend = makeFakeBackend({
+      name: 'rest',
+      upload: async (bytes): Promise<MediaItem> => {
+        uploadedBytes = bytes;
+        return {
+          id: 999,
+          title: 'photo',
+          filename: 'photo.jpg',
+          url: 'https://example.test/photo-999.jpg',
+          mimeType: 'image/jpeg',
+          uploadedAt: '2024-01-01',
+        };
+      },
+    });
+
+    // REST-only: no replace-in-place capability → upload-as-new fallback.
+    const resolver: ResolverLike = {
+      resolve: (c) => {
+        if (c === 'upload') return uploadBackend;
+        throw new Error(`unexpected resolve('${c}')`);
+      },
+      tryResolve: () => null,
+    };
+
+    const writeSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    let outcome: Awaited<ReturnType<typeof restoreSnapshot>>;
+    try {
+      outcome = await restoreSnapshot(snap, resolver, store, false);
+    } finally {
+      writeSpy.mockRestore();
+    }
+
+    expect(outcome.status).toBe('partial');
+    expect(outcome.newAttachmentId).toBe(999);
+    expect(uploadedBytes?.toString()).toBe('original bytes');
+  });
 });


### PR DESCRIPTION
Fixes #119.

## Problem

On REST-only sites (no `replace-in-place` capability), undoing a binary snapshot uploads the original as a **brand-new attachment** and leaves the target attachment (`#wpId`) unchanged — but `undo` still called `markRestored(snap.id)` and reported `status: 'restored'`.

Consequences:
- The snapshot is consumed (excluded by the `restored_at IS NULL` filter in `getLastSnapshotForAttachment`), so the user **can never retry** the real in-place restore after later adding SSH/WP-CLI.
- Every reference still points at the unchanged attachment, but the output claims a successful restore — silently misleading.

## Fix

`restoreSnapshot` now returns `{ status: 'restored' | 'partial', newAttachmentId? }`:

- **In-place restore** (or metadata-only) → `'restored'`: the loop marks the snapshot restored and reverts the processing-history row, as before.
- **Upload-as-new fallback** → `'partial'`: the snapshot is **kept un-restored** (retry stays possible), the new attachment ID is surfaced in both the human output and `--json`, and the message points at `localpress references <id> --update-to <newId>`.

`undo`'s summary and `--json` gain a `partial` count; `restored` no longer includes partials. Partial does not count as a failure (exit stays 0) — it's an actionable, recoverable outcome, distinguishable via `status: 'partial'`.

## Tests

- New unit tests in `test/unit/undo.test.ts`: in-place restore reports `'restored'`; REST-only fallback reports `'partial'` with the new attachment ID and uploads the original bytes.
- Updated the optimize-undo integration test (`wp-rest-commands.test.ts`), which previously asserted the old `restored` behavior on a REST-only site, to expect `partial` + `newAttachmentId` and to use the JSON field for cleanup.

typecheck + lint clean; full unit suite green (599 pass / 0 fail).

---
_Generated by [Claude Code](https://claude.ai/code/session_018KLqDSup6HVMJk8vK1TXjS)_