### PR TITLE
fix(ci): rebuild website on new releases, not just wiki edits

### DIFF
--- a/.github/workflows/rebuild-on-wiki.yml
+++ b/.github/workflows/rebuild-on-wiki.yml
@@ -1,7 +1,15 @@
-name: Rebuild website on wiki change
+name: Rebuild website
+
+# localpress.griffen.codes is a static export -- its docs pages pull wiki
+# content, and its hero displays the latest release version, both fetched
+# only at build time. Neither shows up live until something actually
+# triggers a rebuild. This workflow does that whenever either source
+# changes: a wiki page edit, or a new GitHub release being published.
 
 on:
   gollum: # fires on any wiki page create/edit
+  release:
+    types: [published]
 
 jobs:
   trigger-vercel-rebuild:


### PR DESCRIPTION
## Summary
- The Vercel-hosted marketing site is a static export, so its hero version number and wiki-sourced docs content only refresh when the site actually rebuilds.
- Only wiki page edits triggered that rebuild; new releases didn't, which is why the hero kept showing a stale version (e.g. still v2.4.0 after v2.4.1/v2.4.2 shipped).
- Extends the existing wiki-triggered workflow to also fire on `release: published`, reusing the same job/secret.

## Test plan
- [ ] Merge and confirm the workflow appears with both triggers in the Actions tab
- [ ] Cut the next release and confirm it fires a deploy hook call automatically