### PR TITLE
fix(ci): chain website rebuild off release-please, not on:release:

### DIFF
--- a/.github/workflows/rebuild-on-wiki.yml
+++ b/.github/workflows/rebuild-on-wiki.yml
@@ -1,15 +1,19 @@
-name: Rebuild website
+name: Rebuild website on wiki change
 
 # localpress.griffen.codes is a static export -- its docs pages pull wiki
-# content, and its hero displays the latest release version, both fetched
-# only at build time. Neither shows up live until something actually
-# triggers a rebuild. This workflow does that whenever either source
-# changes: a wiki page edit, or a new GitHub release being published.
+# content at build time, so edits don't show up live until something
+# triggers a rebuild. This handles that for wiki edits specifically.
+#
+# Releases need the same rebuild (the hero displays the latest version,
+# also fetched only at build time), but NOT via an `on: release:` trigger
+# here -- release-please creates every Release using GITHUB_TOKEN, and
+# GITHUB_TOKEN-authored events don't fire other workflows' event triggers
+# (this repo already documents the identical restriction for tag-push in
+# release-please.yml). That path is handled by the `rebuild-website` job
+# chained directly off release-please.yml's own run instead.
 
 on:
   gollum: # fires on any wiki page create/edit
-  release:
-    types: [published]
 
 jobs:
   trigger-vercel-rebuild:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,3 +49,19 @@ jobs:
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
     secrets: inherit
+
+  rebuild-website:
+    name: Rebuild website
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    # The Release this job responds to was just created by release-please
+    # using GITHUB_TOKEN — same as the tag above, GitHub's design means that
+    # does NOT fire an `on: release:` trigger in any other workflow (built to
+    # stop infinite workflow chains). rebuild-on-wiki.yml's `release:`
+    # trigger looks like it should catch this and never will, so this job
+    # exists to actually chain off this run instead of waiting on an event
+    # that's never sent.
+    steps:
+      - name: Trigger Vercel deploy hook
+        run: curl -s -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}"


### PR DESCRIPTION
## Summary
- #246 added `on: release: types: [published]` to trigger a website rebuild on new releases, but it can't actually fire in this repo: release-please creates every Release using `GITHUB_TOKEN`, and GitHub restricts `GITHUB_TOKEN`-authored events from triggering other workflows' event listeners (the exact same reason this repo's tag-push workflow doesn't listen for release-please's own tags either, per the comments in `release-please.yml`).
- Confirmed directly: v2.4.3 published ~20 min ago and no `release`-triggered run shows up anywhere in Actions history.
- Fixes it the way this repo already fixes the identical problem for the binary/Homebrew build: a new `rebuild-website` job chained via `needs`/`if` directly off `release-please`'s own job output, instead of waiting on an event that's never sent.
- Removes the dead `on: release:` trigger from `rebuild-on-wiki.yml` so it doesn't look like working coverage it isn't; that workflow goes back to wiki-only, with a comment pointing at where the release path actually lives now.

## Test plan
- [ ] Merge and confirm the next release-please-merged release fires the new `rebuild-website` job (visible in the same workflow run as `Release PR / tag` and `Build & publish`)
- [ ] Confirm the site hero updates to the new version shortly after