### PR TITLE
docs: post-v2.4.5 audit — bug findings and scoped new work

### DIFF
--- a/docs/audit-2026-07-v2.4.5.md
+++ b/docs/audit-2026-07-v2.4.5.md
@@ -1,0 +1,809 @@
+# Post-v2.4.5 audit — bugs & new work
+
+Audit performed against `localpress` @ **v2.4.5** (`05bd5a1`) and `localpress-www` @ `main`, July 2026.
+
+Baseline: `bun run typecheck` clean, `bun run lint` clean, `bun test test/unit/` → **747 pass / 4 skip / 2 fail**. The two
+failures are real defects, not flakes — see B-01 and B-02.
+
+Every item below was traced in source and, where marked **verified**, reproduced. Items are written to be pasted
+directly into GitHub issues. Prior audit waves (#94–#218) are all closed; nothing here duplicates them.
+
+Verified counts, for reference when fixing doc drift:
+
+| Thing | Actual |
+| --- | --- |
+| CLI commands registered | **39** (`src/cli/index.ts:88-127`) |
+| MCP tools | **exactly 47** (`grep -c registerTool src/cli/mcp/tools.ts`) |
+| MCP resources | **4** (`src/cli/mcp/resources.ts:34-77`) |
+| `SCHEMA_VERSION` | **5** (`src/engine/state/schema.ts:18`) |
+| Unit tests | **753 across 66 files** |
+
+---
+
+## Table of contents
+
+- [P1 — correctness bugs that mislead the user or destroy data](#p1--correctness-bugs-that-mislead-the-user-or-destroy-data)
+- [P2 — real defects, narrower blast radius](#p2--real-defects-narrower-blast-radius)
+- [P3 — contract & doc drift](#p3--contract--doc-drift)
+- [localpress-www bugs](#localpress-www-bugs)
+- [New work — features & extensions](#new-work--features--extensions)
+
+---
+
+# P1 — correctness bugs that mislead the user or destroy data
+
+## B-01 · `briefing` reports "everything clean" for a site it could not reach at all
+
+**Severity: high.** `briefing` is the flagship "what does my site need today?" command and the `site_briefing` MCP tool.
+
+`runBriefing` sums `count` across all five categories (`src/cli/commands/briefing.ts:125`). An *unavailable* category
+still has `count: 0`, so a total scan failure produces `totalIssues: 0` → `clean: true`
+(`briefing.ts:140`) → `synthesizeNarrative` short-circuits to the canned all-clean text (`briefing.ts:306`). Exit code 0.
+
+Separately, `runA11yCheck` (`briefing.ts:229-249`) reads only `result.findings` and throws away the
+`errors` / `truncated` / `complete` fields that `runA11yScan` returns *specifically* so callers can distinguish
+"clean" from "couldn't scan". So the a11y category reports `available: true, count: 0` even when every request failed.
+
+**Verified** against an unreachable site:
+
+```
+$ localpress briefing --json      # site = https://nonexistent.invalid
+totalIssues: 0
+clean: true
+narrative: "Everything checked out clean on 'dead' — no unoptimized images, missing alt text,
+            broken references, orphaned files, or accessibility issues found."
+a11y category: {"count": 0, "examples": [], "available": true}
+EXIT=0
+
+$ localpress a11y --json          # same site, same moment
+postsChecked: 0   complete: false   errors: 2   EXIT=4
+```
+
+The `a11y` command gets this right (it was fixed in #160). `briefing` re-introduces the same false-clean defect class
+by discarding the signals `a11y` computes.
+
+**Fix direction:** derive `clean` from `totalIssues === 0 && every category available`; add a top-level
+`complete` / `degraded` field to the `--json` contract; never emit the canned clean narrative when any category is
+unavailable; exit `ExitCode.NetworkError` when every category failed. Map `runA11yScan`'s `errors.length > 0`
+→ `available: false` + reason, and `truncated.length > 0` → a note on the category.
+
+## B-02 · `--encoder jsquash` hard-fails for jpeg, webp and avif
+
+**Severity: high.** A documented, advertised feature is broken for 3 of its 4 formats. This is the cause of the failing
+`test/unit/jsquash-buffer.test.ts` JPEG round-trip test on `main`.
+
+The `@jsquash/{jpeg,webp,avif}` emscripten builds are compiled for `-sENVIRONMENT=web,worker`. The non-web branch of the
+emscripten shell is an **empty `else {}`**, so `readBinary` / `readAsync` are never defined
+(`node_modules/@jsquash/jpeg/codec/enc/mozjpeg_enc.js`). That leaves exactly one viable load path:
+`fetch()` + `WebAssembly.instantiateStreaming`. When `instantiateStreaming` is unavailable, control falls to
+`getBinaryPromise` → `ENVIRONMENT_IS_WEB` is false → `getBinarySync` → `readBinary` is `undefined` → throw.
+
+**Verified** on Bun 1.2.14:
+
+```
+$ bun -e 'WebAssembly.instantiateStreaming'
+WebAssembly.instantiateStreaming is not a function
+
+# all three emscripten codecs, .wasm present on disk, fetch(file://) working and returning application/wasm:
+JPEG ENCODE FAIL: Aborted(both async and sync fetching of the wasm failed)
+WEBP ENCODE FAIL: Aborted(both async and sync fetching of the wasm failed)
+AVIF ENCODE FAIL: Aborted(both async and sync fetching of the wasm failed)
+```
+
+`png` is unaffected — `@jsquash/png` / `@jsquash/oxipng` are wasm-bindgen builds with a working Node file-read path,
+which is why the PNG test passes and only the JPEG test fails.
+
+This is **not** a no-network artifact: the `.wasm` files are on disk and `fetch()` of the `file://` URL succeeds with
+`Content-Type: application/wasm`. The failure is purely the missing `instantiateStreaming` + missing non-web fallback.
+
+Note the version surface: CI pins Bun `1.3.14` (`.github/workflows/ci.yml`), which is presumably why this ships green,
+but `package.json` declares `"engines": { "bun": ">=1.1.0" }`, and the tarball wrapper auto-installs whatever Bun is
+current. Anyone on a Bun without `instantiateStreaming` gets a hard crash mid-optimize.
+
+**Fix direction:** stop depending on the codecs' own loader. Read the `.wasm` off disk and hand it to jSquash's
+documented `init(wasmModule)` entry point (or set `Module.wasmBinary`) in `src/engine/image/jsquash.ts` — that is both
+runtime- and Bun-version-independent, and also removes any doubt about the compiled/tarball case. Pair with B-14
+(pre-flight + graceful fallback) and tighten `engines.bun` to a version the project actually tests.
+
+## B-03 · `undo` with no session argument can restore the wrong session
+
+**Severity: high** (wrong bytes written to the live site). Cause of the failing `history.test.ts` test on `main`.
+
+`getLastSession` orders by `started_at DESC LIMIT 1` with **no tie-breaker** (`src/engine/history/store.ts:153-168`).
+`started_at` is millisecond `Date.now()` and session ids are `randomUUID()` strings, so two sessions opened in the same
+millisecond have no defined order. `listSessions` (`store.ts:126-139`) and the query at `store.ts:420` have the same
+omission. The snapshot queries in the same file (`store.ts:297`, `:313`, `:449`) **do** carry `, id DESC` / `, id ASC`
+tie-breaks — so this is an oversight, not a deliberate choice.
+
+`localpress undo` with no session argument is the documented default (`src/cli/commands/undo.ts:153`) and the default of
+the `undo` MCP tool, which makes this reachable from ordinary rapid-fire agent use.
+
+**Verified** — forcing two sessions to share a `started_at`:
+
+```
+both sessions now started_at = 1700000000000 (same millisecond)
+MOST RECENT session is  : remove-bg (c6f9d738)
+getLastSession returned : optimize  (27097fdd)
+RESULT: *** WRONG SESSION — `localpress undo` restores the OLDER run ***
+listSessions order      : optimize , remove-bg   (newest-first expected: remove-bg , optimize)
+```
+
+**Fix direction:** `ORDER BY started_at DESC, rowid DESC` in all three session queries. Consider the schema-level fix in
+N-07 (a monotonic `seq` column) so ordering doesn't depend on `rowid` semantics.
+
+## B-04 · `a11y --limit` is shared across post types, so `pages` can be skipped entirely while the scan claims `complete: true`
+
+**Severity: high** (silent false-clean on half the site).
+
+`postsChecked` accumulates across the `for (const postType of types)` loop, but the loop guard
+`while (postsChecked < limit)` and the `limitReached` flag are per-iteration (`src/cli/commands/a11y.ts:118-119`,
+`:166`, `:175`). Once `posts` consumes the whole budget, the `pages` loop body never executes — **no request is ever
+issued for pages** — and because `limitReached` is re-declared per type, `pages` is never pushed into `truncated`.
+`complete` is then computed as `true` (`a11y.ts:175`).
+
+Verified with a mocked API (default `--limit 100`, 100 posts + 2 pages, one page containing an `<img>` with no alt):
+5 requests issued, **zero** to `/pages`, result `{postsChecked: 100, findings: 0, truncated: [], complete: true}` —
+i.e. "No accessibility issues found. Nice work!" while every page went unchecked. Reachable via the `a11y_audit`
+MCP tool too, and it silently poisons B-01's a11y count.
+
+**Fix direction:** track `postsChecked`/limit per post type (or split the budget), and push a post type into
+`truncated` whenever its scan didn't reach the end of its collection — including when it never started.
+
+## B-05 · `watch --delete` destroys the attachment and its ID on an atomic editor save
+
+**Severity: high** (breaks every reference in post content, irreversibly).
+
+Adds and changes are debounced 800 ms and coalesced through a rerun guard (`src/cli/commands/watch.ts:412-424`), but
+`unlink` is acted on immediately with no debounce (`watch.ts:445-448`), and the delete is `{ force: true }`
+(`watch.ts:379`) — skipping trash.
+
+The project already knows editors save by delete+recreate: `src/engine/editor/watcher.ts:69-72` handles exactly that,
+and `test/unit/editor-watcher.test.ts` has a (currently skipped) "fires onSave on delete+recreate (atomic-save editors)"
+test. Under `watch --delete`, that same sequence force-deletes the WordPress attachment and the following `add`
+uploads a brand-new attachment with a new ID.
+
+Verified against a request-logging fake WP:
+
+```
+rm a.png  → GET media/500 (snapshot) → DELETE /wp/v2/media/500?force=true
+cp a.png  → POST /wp/v2/media → uploaded as #501
+events: {"event":"deleted","attachmentId":500} then {"event":"uploaded","attachmentId":501}
+```
+
+**Fix direction:** debounce `unlink` behind a 2–5 s grace window and cancel the delete if the same relative path
+reappears, mirroring `editor/watcher.ts`. Consider dropping `force: true` in favour of trash.
+
+---
+
+# P2 — real defects, narrower blast radius
+
+## B-06 · `a11y` pagination offset breaks for any `--limit` not a multiple of 20
+
+**Severity: medium.** `perPage = Math.min(20, limit - postsChecked)` (`a11y.ts:120`) shrinks on the final iteration while
+`page` keeps incrementing (`a11y.ts:155`). Since the server-side offset is `(page-1) * per_page`, shrinking `per_page`
+moves the window *backwards* into already-scanned records.
+
+Verified with a mock API honouring `per_page`/`page` (100 posts, `--limit 50`): reported `postsChecked: 50`, but only
+**40 distinct posts** were analyzed — posts 21–30 analyzed twice (inflating `findings` and every `summary.*` counter),
+posts 41–50 never analyzed. Reachable via `a11y_audit({limit})`.
+
+**Fix direction:** keep `per_page` fixed at 20 and truncate the last page client-side, or switch to `offset=`.
+
+## B-07 · `verify` reports any remote fetch failure as "exists locally but not remotely"
+
+**Severity: medium.** `verify` exists to answer "did my writes land?", and it answers "your attachment was deleted"
+whenever the site is merely unreachable or the credentials are wrong.
+
+`adapter.getMedia(id)` throws `WpApiError` *with* a `.status` for HTTP failures and a plain fetch error for connectivity
+failures (`src/adapters/rest.ts:107-110`). `verify` treats all of them as missing-remote
+(`src/cli/commands/verify.ts:186-205`); the untracked path at `:163-177` uses a bare `catch {}` and discards the reason
+entirely.
+
+Verified against a fake WP returning 401:
+
+```
+verify 123 --json → {"missing":1,"results":[{"status":"missing-remote",
+                     "findings":[{"field":"remote-record","remote":null,"severity":"missing"}]}]}
+verify 999 --json → warn "#999: not found locally or remotely"   (no reason given at all)
+```
+
+A bad Application Password makes **every** attachment look deleted, and the JSON carries neither the status code nor a
+message for a consumer to tell the difference.
+
+**Fix direction:** classify as `missing-remote` only on HTTP 404. Add `status: 'unreachable'` (or an `errors[]` +
+reason field) for 401/403/5xx/network, and keep those out of `missingCount`.
+
+## B-08 · `verify` emits `status: "ok"` for items whose hash check could not be performed
+
+**Severity: low-medium**, and it contradicts the file's own stated invariant (`verify.ts:279-281`: *"the latter must
+never report as ok"*).
+
+`status` is derived purely from `findings.length` (`verify.ts:305-316`), so an item whose `--hash` check failed comes
+out as `{"status":"ok","hashVerified":false}`. Verified against a fake WP whose media file returns 403:
+
+```
+{"verified":1,"ok":0,"drift":0,"missing":0,"unverified":1,
+ "results":[{"status":"ok","findings":[],"hashVerified":false}]}   EXIT=1
+```
+
+The summary counters are honest; only `results[].status` lies. Secondary: a drifted-*and*-unverified item increments
+both `driftCount` and `unverifiedCount`, so `ok+drift+missing+unverified` can exceed `verified`.
+
+**Fix direction:** add a distinct `status: 'unverified'` and make the four counters a strict partition.
+
+## B-09 · `doctor` always exits 0, even when the connection check failed
+
+**Severity: medium** — it makes `doctor` unusable as a CI/scripting gate, and silently breaks the `health_check` MCP
+tool, which decides `doctor.ok` from the exit code (`src/cli/mcp/tools.ts:1705-1713`).
+
+No diagnostic path sets `process.exitCode`; the only exit is the "no sites configured" case, via a hardcoded `3`
+(`src/cli/commands/doctor.ts:102`).
+
+**Verified:** unreachable site → `connectionOk: false` plus an `error`-severity issue, `EXIT=0` in both human and
+`--json` mode.
+
+**Fix direction:** set `process.exitCode = ExitCode.NetworkError` / `AuthError` when any `error`-severity issue is
+present, and replace the literal `3` with `ExitCode.ConfigError`.
+
+## B-10 · `doctor`'s unreachable-host detection never fires on Bun, losing the remediation hint
+
+**Severity: medium.** The branch keys off `msg.includes('ENOTFOUND') || msg.includes('ECONNREFUSED')`
+(`doctor.ts:130-142`), but Bun's `fetch` rejects with messages like
+`Unable to connect. Is the computer able to access the url?`. Neither substring matches, so the most common failure mode
+falls into the generic bucket **with no `fix` field** — and `--fix` only echoes issues that have one.
+
+**Verified:**
+
+```
+Issues:
+  ✗ REST API error: Unable to connect. Is the computer able to access the url?      ← no "→ fix" line
+```
+
+**Fix direction:** branch on the error's `code`/`cause` (or on the absence of `WpApiError.status`) rather than message
+substrings; keep the string check as a fallback.
+
+## B-11 · `briefing` caches a failed/degraded result forever
+
+**Severity: medium.** The result is cached unconditionally after every run and the cache has no TTL and no invalidation
+(`briefing.ts:81-91`, `:96`). One run during an outage — or with Ollama down, yielding
+`narrativeUnavailable: true` — pins that answer indefinitely; every later `localpress briefing` / `site_briefing` call
+serves the stale degraded payload until someone thinks to pass `--fresh`.
+
+**Verified:** second and third invocations returned the identical failed payload with `fresh: false` and the original
+`generatedAt`.
+
+**Fix direction:** don't cache when any category is unavailable or the narrative failed; add a TTL.
+
+## B-12 · `watch --delete` ignores the global `--dry-run`
+
+**Severity: medium.** There is no `resolveDryRun` (or any `dryRun` read) anywhere in `src/cli/commands/watch.ts`, though
+`--dry-run` is a global option (`src/cli/index.ts:73`) and CLAUDE.md requires destructive commands to route through the
+shared helper. **Verified:** `watch <dir> --delete --dry-run --json` uploaded the new file *and* issued
+`DELETE …?force=true` on removal. `watch` was not in the scope of the earlier dry-run gating wave (#190/#219).
+
+## B-13 · `watch` silently does nothing when the watch root contains a dot-prefixed path component
+
+**Severity: low.** `ignored: [/(^|[/\\])\../, …]` (`watch.ts:436-441`) is matched by chokidar against **full** paths, so
+an absolute root like `~/.local/share/photos` matches the dotfile rule and every event is filtered. The command still
+prints "Watching … for changes" and never errors.
+
+**Verified:** identical add/change/delete scenarios produced zero events under `<repo>/.tmp/watched` and worked
+correctly under `<repo>/tmp-watched`.
+
+**Fix direction:** anchor the dotfile rule to paths *relative to* the watch root.
+
+## B-14 · MCP `runCli` discards `structuredContent` on any non-zero exit, including deliberate partial-failure signals
+
+**Severity: medium.** `runCli` returns `{ isError: true, content: [text] }` with **no** `structuredContent` whenever
+`result.ok` is false (`src/cli/mcp/tools.ts:59-72`). But several commands print a complete, trustworthy `--json`
+payload and *then* exit non-zero as a signal:
+
+- `a11y.ts:237-246` — prints findings, then sets exit 4 if any post fetch failed
+- `caption.ts:395-413`, `delete.ts:202-211`, `metadata.ts:221-226`, `classify.ts:143-148`, `regenerate.ts:142-148`
+
+So the agent gets a hard error with the JSON buried in a text blob, and structured consumption breaks *precisely* on
+partial-failure runs. The codebase already documents this exact hazard — but only for the batched path
+(`tools.ts:150-165`, `resolveChunkOutput`).
+
+**Fix direction:** in `runCli`, always attach `structuredContent` when stdout parses to an object; set `isError` only
+when there is no parseable payload.
+
+## B-15 · `references` MCP tool performs a site-wide destructive rewrite with no preview and no warning
+
+**Severity: medium.** The tool is titled "Find references to an attachment" and described purely as a read
+(`tools.ts:549-577`); `updateTo` is documented only as "Rewrite references to point to a different attachment ID".
+
+But `references.ts:61` calls `resolveDryRun(parentOpts, false)` — it **executes by default** — and then runs
+`wp db query "UPDATE …postmeta…"`, `wp search-replace <oldUrl> <newUrl> --precise` across **all tables**, and a regex
+`search-replace` on `post_content` (`references.ts:87-120`). The tool exposes no `dryRun`/`apply`/`confirm` parameter,
+unlike `delete` and `posts_delete`, which both gate on `confirm`.
+
+**Fix direction:** add `dryRun` to the schema (mapping to the global flag) and move the destructive warning into the
+tool description.
+
+## B-16 · `stats` "Optimized: N (P%)" counts *any* successful operation
+
+**Severity: low-medium.** `getLibraryOverview().optimized` is
+`COUNT(DISTINCT wp_id) FROM processing_history WHERE status='success'` with no operation filter
+(`src/engine/state/db.ts:320-326`), so a caption/title/tag/classify/rename/metadata pass makes an image count as
+"Optimized" — and `unoptimized = total - optimized` then reports 0 images needing work.
+
+**Verified:** attachment with a single `caption` success → `Optimized: 1 (100.0%) / Unoptimized: 0`, while
+`optimize --unoptimized` (which *does* filter) still correctly selects it.
+
+Same root cause as B-17. Worth noting in the issue: `totalAttachments` is the row count of the *local* `attachments`
+table, so both the "Library" label and the percentage denominator are narrower than users will read them.
+
+**Fix direction:** restrict the query to `operation IN ('optimize','convert','resize')` and relabel the section.
+
+## B-17 · `briefing`'s `unoptimized` count treats caption/tag/rename passes as "already optimized"
+
+**Severity: low.** `briefing.ts:181` calls `db.listProcessedWpIds(siteName)` without the `operations` filter — whose own
+doc comment (`db.ts:146-152`) exists precisely to stop "a caption/classify/rename pass … [making] an image look
+'already optimized'". `optimize.ts:470` passes `['optimize','convert','resize']`; `briefing` does not, so it
+under-reports.
+
+Triage note: `audit.ts:196`, `list.ts:108/385` and `export.ts:129` share the unfiltered call, so you may prefer to
+treat this as one cross-cutting issue with B-16 rather than a `briefing` bug.
+
+## B-18 · `stats --all-sites --json` flips between object and array
+
+**Severity: low**, but `--json` shapes are a public API. `printJson(results.length === 1 ? results[0] : results)`
+(`stats.ts:86`) means `--all-sites` emits a bare object for a one-site config and an array for two or more.
+Via MCP there's a *third* shape: `runCli` wraps arrays as `{ items: [...] }` (`tools.ts:84-90`).
+**Verified** with 1 vs 2 configured sites.
+
+**Fix direction:** always emit an array (or `{ sites: [...] }`) for `--all-sites`.
+
+## B-19 · `doctor --fix --json` can emit non-JSON on stdout
+
+**Severity: low.** *Trace-only — could not execute, since sharp is installed in the audit environment.*
+When sharp is missing, `--fix` calls `installSharpGlobally()` (`doctor.ts:161-176`), which spawns
+`bun|npm install -g sharp` with `stdio: 'inherit'` (`src/engine/image/sharp-loader.ts:126-146`) — the package manager's
+progress output lands on stdout ahead of the JSON object, breaking any `--json` consumer including the `doctor` MCP tool.
+
+**Fix direction:** pipe the child's stdio and summarize via `info()`/`warn()`, or refuse to auto-install in `--json` mode.
+
+## B-20 · `optimize` records pre-processing `width`/`height` after replace-in-place, causing permanent false `verify` drift
+
+**Severity: low.** `optimize.ts:940-941` writes `width`/`height` from the *pre*-processing `MediaItem`, unlike
+`resize.ts:216-217` which updates them. After `optimize --max-width …` with replace-in-place, `verify` reports
+`width`/`height` mismatch findings forever. (The `--hash`/size/mime bookkeeping is correct — that was fixed in #226.)
+
+## B-21 · `watch --delete` opens a history session at startup that is only closed on SIGINT/SIGTERM
+
+**Severity: low.** `watch.ts:129-133` opens an empty `watch-delete` session on every run whether or not anything is ever
+deleted; a `SIGKILL`ed watcher leaves it dangling. Related: the `--strict` skip path (`watch.ts:236-241`) reports via
+`warn()` only, so in `--json` mode a skipped file produces a stderr `{"level":"warn"}` line rather than an NDJSON event
+— the documented stdout event stream silently omits it.
+
+---
+
+# P3 — contract & doc drift
+
+## B-22 · `stats --json` in SKILL.md matches the real payload in **zero** keys
+
+**Severity: medium** — SKILL.md is the agent-facing contract.
+
+`skill/SKILL.md:261-281` documents a flat payload: `filesProcessed`, `operationsSucceeded`, `operationsFailed`,
+`bytesBefore`, `bytesAfter`, `bytesSaved`, `percentReduction`, `lastRunAt`, `breakdown`.
+
+Actual output (`stats.ts:70-83` + `db.ts:593-604`) is nested:
+`{ site, url, stats: { siteName, filesTouched, totalOps, succeeded, failed, skipped, bytesSaved, bytesIn, lastRanAt, byOperation }, overview, formats, recent, history }`.
+
+Every documented key except `site` is wrong; `bytesSaved` exists but at the wrong depth; `percentReduction`,
+`bytesAfter` and `breakdown` don't exist at all, and `lastRanAt` is epoch ms rather than the documented ISO string.
+The `stats` MCP tool and the `localpress://stats` resource return the same payload verbatim, so an agent following
+SKILL.md reads `undefined` everywhere.
+
+## B-23 · SKILL.md's exit-code "known exceptions" section describes two bugs that are already fixed
+
+**Severity: medium** — it actively instructs agents to distrust correct behaviour.
+
+`SKILL.md:957-964` claims two live defects "tracked in #128, open as of this writing" and tells agents to
+*"treat 1 as generic failure … rather than assuming JSON is always available."* Both are fixed:
+`src/cli/index.ts:172-179` catches `CommanderError` and exits `ExitCode.InvalidUsage`; `index.ts:129-132` applies
+`exitOverride()` recursively; `index.ts:196-199` routes generic errors through the JSON-aware `error()` helper.
+
+**Verified:** `bogus-command --json` → `{"level":"error","message":"unknown command 'bogus-command'"}`, exit **2**;
+`list --bogus --json` → JSON on stderr, exit **2**; `show --json` (missing arg) → JSON on stderr, exit **2**.
+
+**Fix direction:** delete the section. Consider closing #128.
+
+## B-24 · `verify` is absent from the entire agent surface
+
+**Severity: medium (gap).** `verify` shipped in v2.4.0 (`index.ts:52`, `:120`) and emits
+`{ site, verified, ok, drift, missing, unverified, results }` (`verify.ts:328-336`) — but it has **no MCP tool**
+(not among the 47), **no SKILL.md section**, and **no README table row**. The one command designed to answer "did my
+writes actually land?" is invisible to the audience that most needs it.
+
+Note for whoever adds the tool: `verify` exits 1 whenever it finds drift (`verify.ts:339-340`), so it needs B-14 fixed
+first or it will surface as a hard error.
+
+## B-25 · MCP schema gaps: real CLI capability an agent cannot reach
+
+**Severity: low-medium.** Checked every tool's argv builder against `--help`.
+
+- **`audit`** omits `--unattached` entirely (CLI flag `audit.ts:64`, finding type `:33`, summary key `:336`), so
+  "find media not attached to any post" is unreachable and agents parsing `summary` won't expect `unattached`.
+- **`optimize`** omits 7 real flags (`tools.ts:587-611`): `--force`, `--target-size`, `--mode`, `--larger-than`,
+  `--keep-original`, `--no-replace-in-place`, `--regenerate-thumbnails`. `--force` matters most — because optimize is
+  idempotent by hash, an agent re-encoding at a new quality gets a silent skip with no override.
+- **`--fallback-model`** is missing from all six AI tools (`caption`, `generate_title`, `generate_description`, `tag`,
+  `vision`, `classify`) — it's the documented mitigation for garbage vision output.
+- Smaller gaps: `convert`/`resize`/`remove_bg` missing `--keep-original` (plus `resize --quality`,
+  `remove_bg --trim`/`--list-models`); `caption` missing `--prompt`/`--ollama-url`; `push` missing
+  `--description`/`--post`; `pull` missing `--include-sizes`/`--force`; `sites_remove` missing `--keep-db`.
+- No tool for `config list`, `config remove-profile` (asymmetric with the three profile tools that do exist),
+  `sites run` (which SKILL.md documents with a full output example at `:98-116`), or `history clear`.
+- **`--dry-run` is unreachable from almost every mutating tool.** Only `rename` and `import` expose it, yet `delete`,
+  `update_metadata`, `posts_update`, `posts_delete`, `push` and `references(updateTo)` all honour the global flag.
+  Dry-run is the CLI's core safety primitive; its near-total absence from the tool surface is a real asymmetry.
+
+## B-26 · Version and count drift in CLAUDE.md / README / SKILL.md
+
+**Severity: low.**
+
+| Location | Claim | Actual |
+| --- | --- | --- |
+| `CLAUDE.md:3`, `:16` | v2.4.4 | **2.4.5** |
+| `CLAUDE.md:56`, `:129`, `:230` | schema v4 | **5** (`schema.ts:18`) |
+| `CLAUDE.md:84` | 232 tests / 23 files | **753 / 66** |
+| `CLAUDE.md:193` | "37 commands" | **39** — and contradicts `CLAUDE.md:21` ("39") in the same file |
+| `CLAUDE.md:72`, `:209`; `README.md:142`; `SKILL.md:928` | "47+ tools" | exactly **47** |
+| `README.md:118-136` | command table | omits `verify` and `watch-status` |
+
+## B-27 · Remaining SKILL.md JSON-example drift
+
+**Severity: low.** Individually trivial, collectively the reason agents mis-parse output.
+
+- `caption --json` (`SKILL.md:407-421`) omits top-level `dryRun` and `skipped` (`caption.ts:395-401`) — so an agent
+  can't distinguish a dry-run from a real run, or count idempotent skips. SKILL.md gets this right for
+  `title`/`describe`/`tag`/`rename`, so it's an inconsistency rather than a systemic gap.
+- `audit --json` (`SKILL.md:239-257`) omits `prunedAttachments` (`audit.ts:325`) and `summary.unattached` (`:336`).
+- `a11y --json` (`SKILL.md:634-646`) omits `errors`, `truncated`, `complete` (`a11y.ts:242-244`), and doesn't mention
+  that `a11y.ts:246` sets exit **4** while still returning a valid partial payload.
+- `SKILL.md:215` cites `list.ts:437` for the `list --json` shape; the actual `printJson` is `list.ts:394`.
+- `SKILL.md:368-377` presents one bulk dry-run shape as canonical. There are **six**, and the discriminator itself
+  flips between `dryRun: true` and `action: 'dry-run'`: `optimize.ts:499`, `export.ts:175`, `import.ts:288`,
+  `metadata.ts:81`, `delete.ts:72`, `regenerate.ts:93`, `posts.ts:358/459/520`. An agent cannot write one detector.
+- `SKILL.md:935` calls `--json` "NDJSON"; only `watch` is NDJSON. Contradicts `SKILL.md:73`.
+- `SKILL.md:~880` omits `edit` (`edit.ts:190`) and `classify` (`classify.ts:112`) from the snapshot-capturing list;
+  both do capture.
+- `src/cli/mcp/server.ts:30` (the server `instructions` — the first thing the host model reads) claims
+  "Bulk ops (list+optimize/convert/resize/caption with --unoptimized or --all) are dry-run by default", but `convert`
+  and `resize` take `<ids...>` only and have no `--all`/`--unoptimized`, and `list` isn't a bulk op.
+
+## B-28 · `optimize --to` help text omits `png`
+
+**Severity: low.** `optimize.ts:88-90` says "convert during optimization: webp, avif, or jpeg". PNG is fully supported —
+`ImageFormat` includes it (`src/engine/image/types.ts:8`), the smart-classify default explicitly *selects* png
+(`optimize.ts:577`), the MCP tool's enum correctly includes it (`tools.ts:594`), and `optimize 1 --to png` parses fine.
+Humans reading `--help` believe PNG output is impossible.
+
+---
+
+# localpress-www bugs
+
+Audited with a real install and build: `npx tsc --noEmit` clean, `bun run build` succeeds (14 pages, all 8 doc slugs
+prerendered), `bun run lint` **fails**. All 8 wiki pages were fetched and diffed against the rendered HTML, and a
+controlled failure build was run to prove W-03.
+
+## W-01 · Every cross-page docs link is dead (20 links across 7 of 8 doc pages)
+
+**Severity: high.** `isInternal = href.startsWith("/") || href.startsWith("#")`
+(`components/docs/DocsContent.tsx:35`). GitHub-wiki relative links (`./MCP-Setup`, `WP-CLI-SSH-Setup`) match neither, so
+they take the external branch and are emitted verbatim with `target="_blank"`. Verified in built output:
+
+```
+out/docs/getting-started.html      : ./AI-Agent-Integration  ./Commands-Reference  ./Configuration
+out/docs/mcp-setup.html            : ./AI-Agent-Integration  ./Commands-Reference  ./Getting-Started  ./WP-CLI-SSH-Setup
+out/docs/commands-reference.html   : ./History-And-Undo  ./MCP-Setup  Ollama-Setup
+out/docs/history-and-undo.html     : ./Commands-Reference  ./Configuration  ./MCP-Setup
+out/docs/ai-agent-integration.html : ./MCP-Setup
+out/docs/configuration.html        : WP-CLI-SSH-Setup
+```
+
+`./MCP-Setup` from `/docs/ai-agent-integration` resolves to `/docs/MCP-Setup` → 404, in a new tab.
+
+**Fix direction:** strip the leading `./`, map the remainder against `wikiPath` in `lib/wiki-manifest.ts` → internal
+`<Link href="/docs/{slug}">`, and fail the build on an unmapped bare-relative href.
+
+## W-02 · No heading IDs, so every in-page anchor is dead — including the site's own CTA
+
+**Severity: high.** No `rehype-slug`, and the `h2`/`h3` overrides destructure only `children`
+(`DocsContent.tsx:12`, `:20`) so an `id` would be dropped anyway. `out/docs/getting-started.html` has 7 `<h2>`, none
+with an `id`. Concrete victim: `components/VisionAI.tsx:184` links to `/docs/commands-reference#vision`;
+`grep -c 'id="vision"'` on the target → **0**. The CTA scrolls nowhere on a 942-line reference page.
+
+**Fix direction:** add `rehype-slug`, pass `id` through the heading overrides, and add a TOC rail for the commands
+reference.
+
+## W-03 · A wiki fetch failure silently ships 8 empty doc pages and exits 0
+
+**Severity: high**, and the release-please deploy hook makes it live: one GitHub blip during a release deploy replaces
+all documentation with HTTP-200 empty pages that are still advertised in the sitemap.
+
+`lib/wiki.ts:23-26` returns `null` on any failure; `app/docs/[slug]/page.tsx:72-77` renders a "couldn't be loaded"
+placeholder. **Proven** by pointing `WIKI_RAW_BASE` at a bad host (then reverting):
+
+```
+next build → EXIT=0
+out/docs/getting-started.html : 33KB, 0 <h2>, "This page couldn't be loaded at build time."
+out/sitemap.xml               : still advertises /docs/getting-started
+```
+
+There is also no `AbortSignal.timeout`, so a hung connection stalls the build indefinitely.
+
+**Fix direction:** count failures and throw; add timeout + retry; exclude failed slugs from `sitemap.ts` and emit
+`robots: { index: false }` for them.
+
+## W-04 · `sharp` is an undeclared dependency of `prebuild`
+
+**Severity: medium-high** (build break waiting to happen). `prebuild` (`package.json:6`) runs
+`scripts/generate-og-image.ts`, which imports `sharp` (`:11`) — and `sharp` appears in **neither** `dependencies` nor
+`devDependencies`. It resolves only via a stale `bun.lock:916` entry; the root deps at `bun.lock:5-25` don't list it.
+Proven: a fresh `package.json`-only install produced no `node_modules/sharp`, and it worked only through Bun's network
+auto-install fallback. A lockfile regen, `--frozen-lockfile`, or any non-Bun installer breaks `prebuild`.
+`scripts/` is also excluded from `tsconfig.json:38`, so it's never typechecked.
+
+The `ignoreScripts: ["sharp", …]` field is also non-standard and would *break* sharp's install if it were honoured.
+
+**Fix direction:** `bun add -d sharp`; delete the bogus `ignoreScripts` field. Better: adopt N-11 and delete the script.
+
+## W-05 · Nav, footer and docs-sidebar text fail WCAG 1.4.3 in both themes
+
+**Severity: medium-high** — especially awkward for the site that markets `localpress a11y`.
+
+Contrast ratios computed from the actual tokens in `app/globals.css:11-12`, `:36-37`:
+
+| Token | Dark on `--bg` | Light | AA needs |
+| --- | --- | --- | --- |
+| `--muted` | **1.78:1** (1.56 on `--raised`) | **2.07:1** | 4.5 |
+| `--dim` | **2.94:1** | **3.32:1** | 4.5 |
+
+Both carry real text: header nav (`.hover-ink{color:var(--dim)}`, `globals.css:150`), all footer links, every eyebrow
+label, docs sidebar category labels, "← All docs", "← Previous / Next →", "Edit on GitHub Wiki ↗".
+
+## W-06 · Two nested `<main>` landmarks on every docs page
+
+**Severity: medium.** `app/layout.tsx:102` and `app/docs/layout.tsx:29`. Verified in
+`out/docs/getting-started.html`. Breaks "jump to main content". Fix: make the docs one a `<div>`.
+
+## W-07 · 23 homepage blocks ship `opacity: 0` and need JS to become visible
+
+**Severity: medium.** `components/FadeIn.tsx:56`; `grep -c 'style="opacity:0' out/index.html` → **23**. With JS off or
+the IntersectionObserver failing, most of a fully-prerendered homepage is invisible. There is also **zero**
+`prefers-reduced-motion` handling in the built CSS despite ~23 concurrent 700 ms opacity+transform animations.
+
+## W-08 · Version badge can ship stale, and can disagree with the OG image in the same deploy
+
+**Severity: medium.** `lib/github.ts:31` uses `next: { revalidate: 3600 }`, and Vercel restores `.next/cache` between
+builds — so a deploy-hook rebuild triggered *by* a release can bake the previous version into `components/Hero.tsx:43`.
+Meanwhile `scripts/generate-og-image.ts:22` does an uncached fetch, so the OG card and the hero badge can disagree.
+
+Compounding it, both hardcode `FALLBACK_VERSION = "2.3.0"` (`lib/github.ts:10`, `generate-og-image.ts:20`) while the CLI
+is at **2.4.5**, and the unauthenticated GitHub API is 60 req/hr on shared Vercel build IPs with `GITHUB_TOKEN`
+documented as optional — so the site can silently advertise a two-minor-old version behind a `console.warn`.
+
+**Fix direction:** `cache: "no-store"`; share one version helper between the script and the page; fail loudly rather
+than falling back silently.
+
+## W-09 · `bun run lint` fails
+
+**Severity: medium.** `components/ThemeToggle.tsx:31` — `react-hooks/set-state-in-effect`: `setTheme(getStoredTheme())`
+called synchronously in `useEffect`. It's the only lint error (`tsc` is clean), but it blocks adding any lint gate to CI.
+
+## W-10 · Language-less fenced code blocks get inline-chip styling inside `<pre>`
+
+**Severity: low-medium.** `const isBlock = !!className` (`DocsContent.tsx:58`), but react-markdown only sets
+`className` when the fence declares a language. The 6 bare ``` fences in the wiki (3 in AI-Agent-Integration, 2 in
+History-And-Undo, 1 in Commands-Reference) render as a bordered chip nested inside the bordered `<pre>` — confirmed
+against the 46 correctly-rendered blocks on the same pages. Fix: derive block-vs-inline from node position, not
+`className`.
+
+## W-11 · Stale hardcoded command count
+
+**Severity: low.** `components/Commands.tsx:105` ("38 commands. One tool.") and `lib/wiki-manifest.ts:75`
+("all 38 CLI commands across 12 categories"). Actual: **39**. (The "47+ tools" claims in `Mcp.tsx` / `Features.tsx:34`
+are correct.) See N-10 for the durable fix.
+
+## W-12 · Docs sidebar active state is colour-only, with no `aria-current`
+
+**Severity: low.** `DocsSidebar.tsx:31-40`, `DocsMobileNav.tsx:89-104`;
+`grep -c aria-current out/docs/getting-started.html` → **0**. WCAG 1.4.1. Related:
+`DocsMobileNav.tsx:27` sets `aria-controls` to an element that only exists when the menu is open (`:47`).
+
+## W-13 · `components/Skill.tsx` is dead code that the README documents as shipping
+
+**Severity: low.** `app/page.tsx:1-12` never imports it; `grep -c 'Composes with your' out/index.html` → **0**.
+250 lines — including the WordPress-MCP compatibility table — never ship, while the README lists
+`… Comparison → Skill → Install` as the homepage order.
+
+## W-14 · Icon/favicon assets are inert, and ~14 MB of unreferenced images are deployed
+
+**Severity: low.** `find out -name 'favicon*' -o -name '*.ico'` → only `out/favicon.svg`.
+`app/favicon.png` isn't a Next metadata convention (`favicon.ico` / `icon.png` are), so it's emitted nowhere and
+`scripts/generate-favicons.ts:15,30`'s "covers legacy browsers via Next.js" message is wrong.
+`public/icon-192.png` / `icon-512.png` ship but nothing references them — there's no web manifest anywhere.
+Separately, `public/` is 18 MB, of which 24 files (~14 MB) are referenced by no component, including all of
+`screenshots-windowed/` (5.2 MB, zero references) and two ~2 MB `preview-image.png` files.
+
+## W-15 · Default Next 404 forces a white background over the dark theme
+
+**Severity: low.** No `app/not-found.tsx`, so `out/404.html` carries two `<title>` elements plus inline
+`body{color:#000;background:#fff}` while still rendering the site's dark Header/Footer.
+
+## W-16 · Docs pages have no `og:image`
+
+**Severity: low-medium** — these are the 8 most link-shared URLs on the site.
+`app/docs/[slug]/page.tsx:24-29` sets a child `openGraph` without `images`, which replaces the root object wholesale.
+Verified: `out/index.html` has `og:image` + alt/width/height; `out/docs/getting-started.html` has only
+`og:description/title/type/url`, so those pages render as bare text cards.
+
+## W-17 · Missing canonicals, sitemap not advertised, and `lastmod` is meaningless
+
+**Severity: low.** No `<link rel="canonical">` in `out/index.html` (`app/layout.tsx:28`) or on `/docs`
+(`app/docs/page.tsx:6`) — only `[slug]` sets one. `app/robots.txt` omits a `sitemap:` line and its `Disallow: /api/`
+is dead (a static export has no API routes). And `app/sitemap.ts:11,22,28` stamps `new Date()` on all 10 URLs on every
+build, so every deploy claims everything changed — the opposite of `lastmod`'s purpose, made worse by frequent
+hook-driven deploys.
+
+## W-18 · README stale in four places
+
+**Severity: low.** Claims Inter + Fira Code (actually Fraunces + DM_Mono, `app/layout.tsx:2`); documents `Skill` in the
+homepage order (W-13); lists "What's missing → Open Graph image", which exists and is auto-generated; and says
+"Mobile sidebar drawer … (currently hidden)", which `DocsMobileNav.tsx` implements. It also points at
+`.github/workflows/rebuild-on-wiki.yml`, which lives in the CLI repo, not this one.
+
+### Checked and clean (www)
+
+`generateStaticParams` correct and all 8 slugs prerendered; no static-export incompatibilities (`sitemap.ts` declares
+`dynamic = "force-static"`, no route handlers or server actions); client/server boundaries correct; the theme FOUC
+script + `suppressHydrationWarning` is the right pattern with no hydration issues in the build; heading order valid on
+the homepage and each docs page (exactly one `h1`, no skips) — the H1-strip regex worked on all 8 pages; GFM tables
+render correctly; `tsc --noEmit` clean. Raw HTML in wiki markdown is silently dropped (no `rehype-raw`) — harmless
+today across all 8 pages and the safe default, but worth a build-time warning if `<details>`/`<kbd>` ever appear.
+
+---
+
+# New work — features & extensions
+
+Deliberately *not* a re-run of `docs/roadmap-ideas.md` (~400 ideas, v1.16-era). Each item below came directly out of
+this audit — it either closes a defect class, removes a drift class, or fills a gap the audit exposed.
+
+## N-01 · A shared "scan completeness" contract across every read-only command
+
+**Value: high.** The single most repeated defect class in this codebase is *reporting clean when the scan didn't
+actually run*. It was fixed for `a11y` in #160, and B-01/B-04 show `briefing` reintroducing it — because the fix lived
+in one command instead of in a shared shape.
+
+Introduce a small shared result envelope — `{ complete: boolean, errors: ScanError[], truncated: string[] }` — and make
+`audit`, `a11y`, `briefing`, `verify` and `stats` all populate it, with one helper that decides the exit code from it.
+Then add a single test that asserts every read-only command's `--json` carries the envelope, so the next scan command
+can't ship without it. This is the structural fix that makes B-01, B-04 and B-07 non-recurring rather than three
+one-off patches.
+
+## N-02 · Machine-checked `--json` contracts (kill the SKILL.md drift class)
+
+**Value: high.** B-22, B-27 and the earlier #162/#213 fixes are all the same failure: `--json` is documented as a public
+API but nothing verifies the docs. `stats --json` now matches its documentation in zero keys.
+
+Commit a JSON-schema snapshot per command (generated from a real invocation against the Docker WP fixture), have CI
+fail when a payload drifts from its snapshot, and generate SKILL.md's JSON examples *from* those snapshots.
+`docs/roadmap-ideas.md` has "skill-build — auto-generate SKILL.md"; this is the narrower, higher-value half: the
+CI gate, not the generator.
+
+## N-03 · Encoder pre-flight with graceful fallback
+
+**Value: high**, and it directly de-risks B-02. `caption` already has a pre-flight that validates the Ollama model
+before a 300-item bulk run fails identically 300 times. `optimize --encoder jsquash` has no equivalent: a codec that
+can't load throws per-item, mid-run.
+
+Add a one-time encoder pre-flight that actually attempts a tiny encode for the requested format, and on failure either
+fall back to sharp with a loud warning or fail fast before touching anything — chosen by `--strict`. Surface the result
+in `doctor` (N-04).
+
+## N-04 · Extend `doctor` from "backend capabilities" to "everything this install can actually do"
+
+**Value: high.** `doctor` already probes sharp. It does not probe the jSquash codecs (B-02 would have been caught at
+install time), Ollama reachability + which vision models are pulled, ONNX model cache state, or the Bun version against
+`engines`. Making `doctor` the single "is this install healthy" command — plus B-09's exit codes — turns it into
+something usable in CI and as an agent pre-flight, and makes every "why did my bulk run fail on item 1" report
+self-diagnosing.
+
+## N-05 · One dry-run contract, exposed everywhere
+
+**Value: medium-high.** B-27 found **six** different dry-run payload shapes with the discriminator flipping between
+`dryRun: true` and `action: 'dry-run'`, and B-25 found dry-run unreachable from almost every mutating MCP tool.
+Standardize on one discriminator plus a per-command `changes` block, add `dryRun` to every mutating tool's schema, and
+extend the existing `dry-run-honesty` test to also assert the *output shape*, not just that the gate is consulted.
+Dry-run is the product's core safety promise; it should be uniform and reachable.
+
+## N-06 · Close the agent-surface gaps found in B-24/B-25
+
+**Value: medium-high.** Concretely: a `verify` MCP tool + SKILL.md section + README row; `--unattached` on the `audit`
+tool; `--force` and the other 6 flags on `optimize`; `--fallback-model` on all six AI tools; `config remove-profile`
+and `config list` tools to make profile CRUD symmetric; a `sites run` tool (already documented in SKILL.md with an
+output example, but not implemented). Also worth adding a test that enumerates CLI commands and flags and fails when a
+new one lands without a corresponding tool or an explicit opt-out list — that's what stops this gap from reopening.
+
+## N-07 · Schema v6: give sessions a monotonic ordering key
+
+**Value: medium.** B-03's immediate fix is `ORDER BY started_at DESC, rowid DESC`, but the underlying problem is that
+the only ordering key the schema records is millisecond wall-clock time, on a table whose primary key is a random UUID.
+Add an `INTEGER` autoincrement `seq` to `sessions` and order by it. This also makes `history` paging stable and gives
+`undo` a defensible "previous session" definition.
+
+## N-08 · Briefing cache with a TTL, a staleness marker, and a real cache surface
+
+**Value: medium.** Beyond fixing B-11: give the cache a TTL, surface `cachedAt` / `stale` in the payload, and add
+`briefing --no-cache` alongside `--fresh`. Since `briefing` is the aggregate entry point agents will call first, its
+cache semantics are part of its contract.
+
+## N-09 · `watch` hardening pass
+
+**Value: medium.** B-05, B-12, B-13 and B-21 are all `watch`, and `watch` is the one long-running, unattended,
+destructive-capable command. Worth one focused issue: reuse `editor/watcher.ts`'s atomic-save handling for `unlink`,
+route through `resolveDryRun`, fix the dotfile-root filter, make session lifecycle crash-safe, and emit NDJSON events
+for skips. Plus un-skip the existing `editor-watcher` delete+recreate test, which is currently skipped and covers
+exactly the B-05 scenario.
+
+## N-10 · Make localpress-www derive facts from the CLI instead of hardcoding them
+
+**Value: medium-high**, and it kills a whole recurring class (W-08, W-11, and the "38 commands" drift that has now
+happened twice).
+
+Have the CLI's release pipeline emit a small machine-readable manifest — version, command list with descriptions,
+MCP tool count, capability matrix — as a release asset, and have the website read *that* at build time instead of
+hardcoding `38` / `2.3.0` in four places. The site then cannot drift from the tool it documents, and the CLI's existing
+`--json`-everything design already means the manifest is nearly free to generate.
+
+## N-11 · Replace the sharp OG-image script with `app/opengraph-image.tsx` (Satori)
+
+**Value: medium**, and unusually high leverage: it resolves W-04 (undeclared `sharp`), W-08's duplicate uncached
+version fetch, the committed-binary churn (`public/og-image.png` is git-tracked and rewritten on every build), and a
+rendering bug in one change.
+
+The rendering bug: the generated card asks for `Georgia…serif` and `SF Mono…monospace`
+(`scripts/generate-og-image.ts:79,84,88`), but neither family exists in the Vercel build image and librsvg has no
+webfont support — so the display lines render sans-serif oblique and the "mono" lines render non-monospace. The card
+currently shares *neither* site typeface (Fraunces / DM Mono). Satori with real font buffers fixes that and lets
+per-page docs OG images (W-16) fall out of the same mechanism.
+
+## N-12 · Apply localpress's own accessibility standards to localpress's own website
+
+**Value: medium**, and the credibility argument writes itself: the site selling a WCAG audit command currently fails
+1.4.3 on its primary navigation (W-05), ships two `<main>` landmarks (W-06), hides 23 blocks behind JS with no
+reduced-motion support (W-07), has no `aria-current` (W-12), no skip link, and zero custom focus styles — keyboard
+users traverse 8 header controls on every page with only the UA ring over `#060606`.
+
+Worth doing as one deliberate pass with an axe/Lighthouse CI gate, then writing it up — "we ran our own tool on our own
+site" is the most honest marketing this project could publish.
+
+## N-13 · Docs navigation is missing on mobile, and `/docs` has one heading
+
+**Value: medium.** `components/Header.tsx:32` is `hidden gap-0.5 md:flex` with no mobile menu anywhere in the file, so
+below `md` the entire nav — features, commands, audit, compare, docs — is unreachable from the header on phones.
+Separately, `app/docs/page.tsx:58` renders "Guides"/"Reference" as styled `<div>`s (same in `DocsSidebar.tsx:23`), so
+screen-reader users get one flat list of 8 links, and 1.5 MB of `priority` GIFs (`Hero.tsx:157`, `Showcase.tsx:141`,
+both `unoptimized` because of `output: "export"`) would be better as `<video muted loop playsinline>` — which also
+satisfies WCAG 2.2.2, something an autoplaying GIF cannot.
+
+## N-14 · Build-time link checking for the docs pipeline
+
+**Value: medium.** W-01, W-02 and W-03 are all "the docs build succeeded and shipped something broken". A build step
+that resolves every internal link and anchor against the generated output — and fails the build on a dead target —
+converts all three from silent production breakage into a red build. Given that the site rebuilds automatically on wiki
+edits by non-CI-watching humans, this is the highest-leverage guard the site could add.
+
+---
+
+## Suggested filing order
+
+1. **B-01, B-03, B-04** — false-clean reporting and wrong-session undo. Highest user trust cost, all three verified.
+2. **B-02** — a documented feature is broken; also un-reds the test suite.
+3. **B-05 + N-09** — the only unattended destructive command.
+4. **W-01, W-02, W-03** — every docs cross-link is dead and the pipeline can ship empty pages silently.
+5. **B-22, B-23, B-24** — the agent-facing contract actively misinforms agents today.
+6. **N-01, N-02** — the two structural fixes that stop this audit's biggest defect classes from recurring.


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @gfargo :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## What

Adds `docs/audit-2026-07-v2.4.5.md` — a full audit of `localpress` @ v2.4.5 and `localpress-www` @ `main`, written so each item can be pasted straight into a GitHub issue.

- **28 CLI bugs** (5 P1, 16 P2, 7 contract/doc drift)
- **18 localpress-www bugs**
- **14 scoped follow-up items** (features / extensions / structural fixes)

Nothing here duplicates the earlier audit waves — #94–#218 are all closed and were cross-checked.

## Headline findings

- **Two unit tests fail on `main` today.** Both are real defects, not flakes:
  - `--encoder jsquash` cannot load its WASM for **jpeg, webp and avif** (only png works). The emscripten codecs are built `-sENVIRONMENT=web,worker`, so `readBinary` is never defined and the only load path is `fetch` + `WebAssembly.instantiateStreaming` — which doesn't exist on every Bun in the declared `engines` range. Verified directly, and it is *not* a no-network artifact: the `.wasm` is on disk and `fetch(file://…)` succeeds.
  - `getLastSession` has no `ORDER BY` tiebreak, so `localpress undo` with no argument can restore the **wrong session**. Reproduced.
- **`briefing` reports `clean: true`, the canned "everything checked out clean" narrative, and exit 0 for a site it could not reach at all** — while `a11y` on the same site at the same moment correctly reports `complete: false`, 2 errors, exit 4. This is the same false-clean class that #160 fixed for `a11y`.
- **`a11y --limit` is shared across post types**, so `pages` can be skipped entirely — zero requests issued — while the scan still reports `complete: true`.
- **Every cross-page docs link on the website is dead** (20 links across 7 of 8 pages), no heading IDs exist so the site's own `#vision` CTA scrolls nowhere, and a wiki fetch failure ships 8 empty doc pages with exit 0 (proven with a controlled failure build).
- **`stats --json` matches its SKILL.md documentation in zero keys**, and SKILL.md still tells agents to distrust exit code 2 for two bugs that are already fixed.

## Verification

Findings are marked verified where reproduced. Baseline: `bun run typecheck` clean, `bun run lint` clean, `bun test test/unit/` → 747 pass / 4 skip / **2 fail**. Behavioural claims were exercised against an unreachable site, a local fake-WP REST server, and mocked `fetch` harnesses; the website claims against a real `bun install` + `next build` with all 8 wiki pages fetched and diffed against rendered HTML. Counts (39 commands, exactly 47 MCP tools, 4 resources, schema v5, 753 tests) were counted rather than taken from docs.

Items checked and found **correct** are recorded too, so nobody re-audits them.

## Notes

- Docs-only change; no source touched.
- `docs/` is gitignored in this repo, so the file is force-added alongside the two already-tracked docs.
- A suggested filing order is at the end of the document.